### PR TITLE
feat: :mag: Add sitemap and robots.txt

### DIFF
--- a/config/backup.conf
+++ b/config/backup.conf
@@ -1,0 +1,163 @@
+(venv) jsolly@django-server:~/blogthedata/django_project$ cd /etc/apache2/sites-available/
+(venv) jsolly@django-server:/etc/apache2/sites-available$ ls
+000-default.conf  default-ssl.conf  django_project_backup.conf  django_project.conf  django_project-le-ssl.conf
+(venv) jsolly@django-server:/etc/apache2/sites-available$ sudo nano default-ssl.conf 
+[sudo] password for jsolly: 
+(venv) jsolly@django-server:/etc/apache2/sites-available$ ls
+000-default.conf  default-ssl.conf  django_project_backup.conf  django_project.conf  django_project-le-ssl.conf
+(venv) jsolly@django-server:/etc/apache2/sites-available$ sudo nano django_project-le-ssl.conf 
+(venv) jsolly@django-server:/etc/apache2/sites-available$ cd ..
+(venv) jsolly@django-server:/etc/apache2$ cd ..
+(venv) jsolly@django-server:/etc$ ls
+adduser.conf                   cron.monthly          groff            landscape       magic                newt               rc0.d          shells             ucf.conf
+adjtime                        crontab               group            ldap            magic.mime           nsswitch.conf      rc1.d          skel               udev
+alternatives                   cron.weekly           group-           ld.so.cache     mailcap              opt                rc2.d          sos                udisks2
+apache2                        cryptsetup-initramfs  grub.d           ld.so.conf      mailcap.order        os-release         rc3.d          ssh                ufw
+apparmor                       crypttab              gshadow          ld.so.conf.d    manpath.config       overlayroot.conf   rc4.d          ssl                update-manager
+apparmor.d                     dbus-1                gshadow-         legal           mdadm                PackageKit         rc5.d          subgid             update-motd.d
+apport                         debconf.conf          gss              letsencrypt     mime.types           pam.conf           rc6.d          subgid-            update-notifier
+apt                            debian_version        hdparm.conf      libaudit.conf   mke2fs.conf          pam.d              rcS.d          subuid             UPower
+bash.bashrc                    default               host.conf        libblockdev     modprobe.d           passwd             resolv.conf    subuid-            usb_modeswitch.conf
+bash_completion                deluser.conf          hostname         libnl-3         modules              passwd-            rmt            sudo.conf          usb_modeswitch.d
+bash_completion.d              depmod.d              hosts            lighttpd        modules-load.d       perl               rpc            sudoers            vim
+bindresvport.blacklist         dhcp                  hosts.allow      locale.alias    mtab                 pki                rsyslog.conf   sudoers.d          vmware-tools
+binfmt.d                       django_config.json    hosts.deny       locale.gen      multipath            pm                 rsyslog.d      sudo_logsrvd.conf  vtrgb
+byobu                          dpkg                  init.d           localtime       multipath.conf       polkit-1           screenrc       sysctl.conf        wgetrc
+ca-certificates                e2scrub.conf          initramfs-tools  logcheck        nanorc               pollinate          securetty      sysctl.d           X11
+ca-certificates.conf           environment           inputrc          login.defs      needrestart          postgresql         security       sysstat            xattr.conf
+ca-certificates.conf.dpkg-old  ethertypes            iproute2         logrotate.conf  netconfig            postgresql-common  selinux        systemd            xdg
+cloud                          fonts                 iscsi            logrotate.d     netplan              profile            sensors3.conf  terminfo           zsh_command_not_found
+console-setup                  fstab                 issue            lsb-release     network              profile.d          sensors.d      thermald
+cron.d                         fuse.conf             issue.net        ltrace.conf     networkd-dispatcher  protocols          services       timezone
+cron.daily                     fwupd                 kernel           lvm             NetworkManager       python3            shadow         tmpfiles.d
+cron.hourly                    gai.conf              kernel-img.conf  machine-id      networks             python3.9          shadow-        ubuntu-advantage
+(venv) jsolly@django-server:/etc$ cd apache2/
+(venv) jsolly@django-server:/etc/apache2$ ls
+apache2.conf  conf-available  conf-enabled  envvars  magic  mods-available  mods-enabled  ports.conf  sites-available  sites-enabled
+(venv) jsolly@django-server:/etc/apache2$ cd ..
+(venv) jsolly@django-server:/etc$ ls
+adduser.conf                   cron.monthly          groff            landscape       magic                newt               rc0.d          shells             ucf.conf
+adjtime                        crontab               group            ldap            magic.mime           nsswitch.conf      rc1.d          skel               udev
+alternatives                   cron.weekly           group-           ld.so.cache     mailcap              opt                rc2.d          sos                udisks2
+apache2                        cryptsetup-initramfs  grub.d           ld.so.conf      mailcap.order        os-release         rc3.d          ssh                ufw
+apparmor                       crypttab              gshadow          ld.so.conf.d    manpath.config       overlayroot.conf   rc4.d          ssl                update-manager
+apparmor.d                     dbus-1                gshadow-         legal           mdadm                PackageKit         rc5.d          subgid             update-motd.d
+apport                         debconf.conf          gss              letsencrypt     mime.types           pam.conf           rc6.d          subgid-            update-notifier
+apt                            debian_version        hdparm.conf      libaudit.conf   mke2fs.conf          pam.d              rcS.d          subuid             UPower
+bash.bashrc                    default               host.conf        libblockdev     modprobe.d           passwd             resolv.conf    subuid-            usb_modeswitch.conf
+bash_completion                deluser.conf          hostname         libnl-3         modules              passwd-            rmt            sudo.conf          usb_modeswitch.d
+bash_completion.d              depmod.d              hosts            lighttpd        modules-load.d       perl               rpc            sudoers            vim
+bindresvport.blacklist         dhcp                  hosts.allow      locale.alias    mtab                 pki                rsyslog.conf   sudoers.d          vmware-tools
+binfmt.d                       django_config.json    hosts.deny       locale.gen      multipath            pm                 rsyslog.d      sudo_logsrvd.conf  vtrgb
+byobu                          dpkg                  init.d           localtime       multipath.conf       polkit-1           screenrc       sysctl.conf        wgetrc
+ca-certificates                e2scrub.conf          initramfs-tools  logcheck        nanorc               pollinate          securetty      sysctl.d           X11
+ca-certificates.conf           environment           inputrc          login.defs      needrestart          postgresql         security       sysstat            xattr.conf
+ca-certificates.conf.dpkg-old  ethertypes            iproute2         logrotate.conf  netconfig            postgresql-common  selinux        systemd            xdg
+cloud                          fonts                 iscsi            logrotate.d     netplan              profile            sensors3.conf  terminfo           zsh_command_not_found
+console-setup                  fstab                 issue            lsb-release     network              profile.d          sensors.d      thermald
+cron.d                         fuse.conf             issue.net        ltrace.conf     networkd-dispatcher  protocols          services       timezone
+cron.daily                     fwupd                 kernel           lvm             NetworkManager       python3            shadow         tmpfiles.d
+cron.hourly                    gai.conf              kernel-img.conf  machine-id      networks             python3.9          shadow-        ubuntu-advantage
+(venv) jsolly@django-server:/etc$ locate ssl.conf
+Command 'locate' not found, but can be installed with:
+sudo apt install mlocate  # version 0.26-5ubuntu1, or
+sudo apt install plocate  # version 1.1.8-1
+(venv) jsolly@django-server:/etc$ sudo apt install mlocate
+Reading package lists... Done
+Building dependency tree... Done
+Reading state information... Done
+Suggested packages:
+  nocache
+The following NEW packages will be installed:
+  mlocate
+0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
+Need to get 50.2 kB of archives.
+After this operation, 283 kB of additional disk space will be used.
+Get:1 http://mirrors.linode.com/ubuntu impish/main amd64 mlocate amd64 0.26-5ubuntu1 [50.2 kB]
+Fetched 50.2 kB in 0s (2,318 kB/s)
+Selecting previously unselected package mlocate.
+(Reading database ... 116867 files and directories currently installed.)
+Preparing to unpack .../mlocate_0.26-5ubuntu1_amd64.deb ...
+Unpacking mlocate (0.26-5ubuntu1) ...
+Setting up mlocate (0.26-5ubuntu1) ...
+update-alternatives: using /usr/bin/mlocate to provide /usr/bin/locate (locate) in auto mode
+Adding group `mlocate' (GID 119) ...
+Done.
+Initializing mlocate database; this may take some time... done
+Created symlink /etc/systemd/system/timers.target.wants/mlocate.timer → /lib/systemd/system/mlocate.timer.
+mlocate.service is a disabled or a static unit, not starting it.
+Processing triggers for man-db (2.9.4-2) ...
+Scanning processes...                                                                                                                                                                        
+Scanning linux images...                                                                                                                                                                     
+
+Running kernel seems to be up-to-date.
+
+No services need to be restarted.
+
+No containers need to be restarted.
+
+No user sessions are running outdated binaries.
+(venv) jsolly@django-server:/etc$ locate ssl.conf
+/etc/apache2/mods-available/ssl.conf
+/etc/apache2/mods-enabled/ssl.conf
+/etc/apache2/sites-available/default-ssl.conf
+/etc/apache2/sites-available/django_project-le-ssl.conf
+/etc/apache2/sites-enabled/django_project-le-ssl.conf
+/var/lib/dpkg/info/openssl.conffiles
+/var/lib/letsencrypt/backups/1633241228.1241584/django_project-le-ssl.conf_0
+/var/lib/letsencrypt/backups/1633241958.2037668/django_project-le-ssl.conf_0
+(venv) jsolly@django-server:/etc$ sudo nano /etc/apache2/mods-available/ssl.conf
+(venv) jsolly@django-server:/etc$ sudo service apache2 restart
+(venv) jsolly@django-server:/etc$ sudo nano /etc/apache2/mods-enabled/ssl.conf
+[sudo] password for jsolly: 
+(venv) jsolly@django-server:/etc$ sudo nano /etc/apache2/sites-available/default-ssl.conf
+(venv) jsolly@django-server:/etc$ sudo service apache2 restart
+(venv) jsolly@django-server:/etc$ sudo nano /etc/apache2/mods-enabled/ssl.conf
+
+  GNU nano 5.6.1                                                                 /etc/apache2/mods-enabled/ssl.conf                                                                          
+        #   Configure the SSL Session Cache: First the mechanism 
+        #   to use and second the expiring timeout (in seconds).
+        #   (The mechanism dbm has known memory leaks and should not be used).
+        #SSLSessionCache                 dbm:${APACHE_RUN_DIR}/ssl_scache
+        SSLSessionCache         shmcb:${APACHE_RUN_DIR}/ssl_scache(512000)
+        SSLSessionCacheTimeout  300
+
+        #   Semaphore:
+        #   Configure the path to the mutual exclusion semaphore the
+        #   SSL engine uses internally for inter-process synchronization. 
+        #   (Disabled by default, the global Mutex directive consolidates by default
+        #   this)
+        #Mutex file:${APACHE_LOCK_DIR}/ssl_mutex ssl-cache
+
+
+        #   SSL Cipher Suite:
+        #   List the ciphers that the client is permitted to negotiate. See the
+        #   ciphers(1) man page from the openssl package for list of all available
+        #   options.
+        #   Enable only secure ciphers:
+        SSLCipherSuite ALL:+HIGH:!ADH:!EXP:!SSLv2:!SSLv3:!MEDIUM:!LOW:!NULL:!aNULL
+
+        # SSL server cipher order preference:
+        # Use server priorities for cipher algorithm choice.
+        # Clients may prefer lower grade encryption.  You should enable this
+        # option if you want to enforce stronger encryption, and can afford
+        # the CPU cost, and did not override SSLCipherSuite in a way that puts
+        # insecure ciphers first.
+        # Default: Off
+        SSLHonorCipherOrder on
+
+        #   The protocols to enable.
+        #   Available values: all, SSLv3, TLSv1, TLSv1.1, TLSv1.2
+        #   SSL v2  is no longer supported
+        SSLProtocol all -TLSv1.1 -TLSv1 -SSLv2 -SSLv3
+        #   Allow insecure renegotiation with clients which do not yet support the
+        #   secure renegotiation protocol. Default: Off
+        #SSLInsecureRenegotiation on
+
+        #   Whether to forbid non-SNI clients to access name based virtual hosts.
+        #   Default: Off
+        #SSLStrictSNIVHostCheck On
+
+</IfModule>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/config/backup_ssl.conf
+++ b/config/backup_ssl.conf
@@ -1,0 +1,46 @@
+        #   to use and second the expiring timeout (in seconds).
+        #   (The mechanism dbm has known memory leaks and should not be used).
+        #SSLSessionCache                 dbm:${APACHE_RUN_DIR}/ssl_scache
+        SSLSessionCache         shmcb:${APACHE_RUN_DIR}/ssl_scache(512000)
+        SSLSessionCacheTimeout  300
+
+        #   Semaphore:
+        #   Configure the path to the mutual exclusion semaphore the
+        #   SSL engine uses internally for inter-process synchronization. 
+        #   (Disabled by default, the global Mutex directive consolidates by default
+        #   this)
+        #Mutex file:${APACHE_LOCK_DIR}/ssl_mutex ssl-cache
+
+
+        #   SSL Cipher Suite:
+        #   List the ciphers that the client is permitted to negotiate. See the
+        #   ciphers(1) man page from the openssl package for list of all available
+        #   options.
+        #   Enable only secure ciphers:
+        SSLCipherSuite HIGH:!aNULL
+
+        # SSL server cipher order preference:
+        # Use server priorities for cipher algorithm choice.
+        # Clients may prefer lower grade encryption.  You should enable this
+        # option if you want to enforce stronger encryption, and can afford
+        # the CPU cost, and did not override SSLCipherSuite in a way that puts
+        # insecure ciphers first.
+        # Default: Off
+        #SSLHonorCipherOrder on
+
+        #   The protocols to enable.
+        #   Available values: all, SSLv3, TLSv1, TLSv1.1, TLSv1.2
+        #   SSL v2  is no longer supported
+        SSLProtocol all -SSLv3
+
+        #   Allow insecure renegotiation with clients which do not yet support the
+        #   secure renegotiation protocol. Default: Off
+        #SSLInsecureRenegotiation on
+
+        #   Whether to forbid non-SNI clients to access name based virtual hosts.
+        #   Default: Off
+        #SSLStrictSNIVHostCheck On
+
+</IfModule>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/django_project/django_project/settings.py
+++ b/django_project/django_project/settings.py
@@ -72,12 +72,17 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
+    "django.contrib.sites",
     "django.contrib.staticfiles",
+    "django.contrib.sitemaps",
     "captcha",
     "ckeditor",
     "ckeditor_uploader",
-    "admin_honeypot"
+    "admin_honeypot",
+    'robots',
 ]
+
+SITE_ID = 1 
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
@@ -88,6 +93,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.utils.deprecation.MiddlewareMixin",
+    'django.contrib.sites.middleware.CurrentSiteMiddleware'
 ]
 
 ROOT_URLCONF = "django_project.urls"
@@ -128,6 +134,12 @@ DATABASES = {
     }
 }
 
+# DATABASES = {
+#         "default": {
+#             "ENGINE": "django.db.backends.sqlite3",
+#             "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
+#         }
+#     }
 
 if any("test" in arg for arg in sys.argv):
     DATABASES = {

--- a/django_project/django_project/sitemaps.py
+++ b/django_project/django_project/sitemaps.py
@@ -1,0 +1,36 @@
+from django.contrib.sitemaps import Sitemap
+from django.urls import reverse
+from blog.models import Post
+
+
+class PostSitemap(Sitemap):
+    changefreq = "weekly"
+    priority = 0.9
+
+    def items(self):
+        return Post.objects.all()
+
+    def lastmod(self, obj):
+        return obj.date_posted
+
+    #def location() Django uses get_absolute_url() by default
+
+class RoadmapSitemap(Sitemap):
+    changefreq = "daily"
+    priority = 0.7
+
+    def items(self):
+        return ['blog-roadmap']
+
+    def location(self, item):
+        return reverse(item)
+
+class StaticSitemap(Sitemap):
+    changefreq = "monthly"
+    priority = 0.5
+
+    def items(self):
+        return ['blog-about']
+
+    def location(self, item):
+        return reverse(item)

--- a/django_project/django_project/urls.py
+++ b/django_project/django_project/urls.py
@@ -15,12 +15,18 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.contrib.auth import views as auth_views
+from django.contrib.sitemaps.views import sitemap
 from django.urls import path, include
 from users.views import register_view, profile_view
 from django.conf import settings
 from django.conf.urls.static import static
+from django_project.sitemaps import PostSitemap, StaticSitemap
+sitemaps = { 'posts' : PostSitemap,
+            'static': StaticSitemap}
 
 urlpatterns = [
+    path("sitemap.xml", sitemap, {'sitemaps': sitemaps}, name='django.contrib.sitemaps.views.sitemap'),
+    path("robots.txt", include('robots.urls')),
     path("", include("blog.urls")),
     path('admin/', include('admin_honeypot.urls', namespace='admin_honeypot')),
     path('config/', admin.site.urls),

--- a/django_project/tests/base.py
+++ b/django_project/tests/base.py
@@ -98,6 +98,8 @@ class SetUp(TestCase):
 
         # Users/Admin urls
         self.honey_pot_url = reverse("admin_honeypot:index")
+        self.sitemap_url = reverse('django.contrib.sitemaps.views.sitemap')
+        self.robots_url = reverse("robots_rule_list")
         self.admin_url = reverse("admin:index")
         self.register_url = reverse("register")
         self.profile_url = reverse("profile")

--- a/django_project/tests/test_urls.py
+++ b/django_project/tests/test_urls.py
@@ -3,6 +3,8 @@ from django.urls import resolve
 from django.conf import settings
 from django.contrib.auth import views as auth_views
 from admin_honeypot.views import AdminHoneypot
+from robots.views import RuleList
+from django.contrib.sitemaps.views import sitemap
 from blog.views import (
     HomeView,
     UserPostListView,
@@ -89,6 +91,14 @@ class TestUrls(SetUp):
 
     def test_admin_honey_pot_url_is_resolved(self):
         self.assertEqual(resolve(self.honey_pot_url).func.view_class, AdminHoneypot)
+    
+    def test_sitemap_url_is_resolved(self):
+        self.assertEqual(resolve(self.sitemap_url).func, sitemap)
+
+    def test_robots_url_is_resolved(self):
+        self.assertEqual(resolve(self.robots_url).func.view_class, RuleList)
+
+        
     # def test_admin_url_is_resolved(self): # wasn't able to figure this one out
     #             self.assertIsInstance(
     #         resolve(self.admin_url).func, AdminSite.index)

--- a/django_project/tests/test_views.py
+++ b/django_project/tests/test_views.py
@@ -251,6 +251,16 @@ class TestViews(SetUp, MiddlewareMixin):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, 'users/logout.html')
 
+    def test_sitemap_view(self):
+        response = self.client.get(self.sitemap_url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_robots_view(self):
+        response = self.client.get(self.robots_url)
+        self.assertEqual(response.status_code, 200)
+        lines = response.content.decode().splitlines()
+        self.assertEqual(lines[0], "User-agent: *")
+
     # password reset #TODO
 
     # password reset-done #TODO


### PR DESCRIPTION
Added sitemap using django's built-in sitemap functionality, django.contrib.sitemaps
The following have been added to the sitemap
- About page
- Roadmap page
- All post detail urls

I also added a new dependency, django-robots, which creates a robots.txt file and adds the sitemap to it.
I've blocked the /admin route to be indexed by Googlebot