### PR TITLE
feat: :lipstick: Add first_name and last_name to user model and reference in template

### DIFF
--- a/django_project/blog/templates/blog/about.html
+++ b/django_project/blog/templates/blog/about.html
@@ -11,7 +11,7 @@
 <div class="card mb-3">
   <div class="row no-gutters">
     <div class="col-md-2">
-      <img src="{{my_profile.image.url}}" class="card-img" alt="John Solly Profile Picture">
+      <img src="{{my_profile.image.url}}" class="card-img" alt=f"{{my_profile.user.first_name my_profile.user.last_name}} Profile Picture">
     </div>
     <div class="col-md-10">
       <div class="card-body">

--- a/django_project/blog/templates/blog/parts/about_me.html
+++ b/django_project/blog/templates/blog/parts/about_me.html
@@ -3,7 +3,7 @@
 <div class="card mb-3">
   <div class="row no-gutters">
     <div class="col-md-2">
-      <img src="{{my_profile.image.url}}" class="card-img" alt="John Solly Profile Picture">
+      <img src="{{my_profile.image.url}}" class="card-img" alt="{{ my_profile.user.first_name }} {{ my_profile.user.last_name }} Profile Picture">
     </div>
     <div class="col-md-10">
       <div class="card-body">

--- a/django_project/blog/templates/blog/parts/posts.html
+++ b/django_project/blog/templates/blog/parts/posts.html
@@ -1,10 +1,10 @@
 {% for post in posts %}
 <article class="media content-section">
-  <img class="rounded-circle article-img" src="{{ post.author.profile.image.url }}" alt="John Solly Profile Picture">
+  <img class="rounded-circle article-img" src="{{ post.author.profile.image.url }}" alt="{{ post.author.first_name }} {{ post.author.last_name }} Profile Picture">
   <div class="media-body">
     <div class="article-metadata">
       <h2 class="article-title"><a class="article-title" href="{% url 'post-detail' post.slug %}">{{ post.title }}</a></h2>
-      <nobr>{{ post.author }} <small class="text-muted">{{ post.date_posted|date:"F d, Y" }}</small>
+      <nobr>{{ post.author.first_name }} {{ post.author.last_name }} <small class="text-muted">{{ post.date_posted|date:"F d, Y" }}</small>
         {% if post.draft %} <span style="color:red"> (Draft)</span> {% endif %}
       </nobr>
     </div>

--- a/django_project/blog/templates/blog/post_detail.html
+++ b/django_project/blog/templates/blog/post_detail.html
@@ -17,7 +17,7 @@
 <meta name="description" content="{{ post.metadesc }}">
 <meta property="og:type" content="article">
 <meta property="article:published_time" content="{{ post.date_posted|date:'c' }">
-<meta name="author" content="John Solly">
+<meta name="author" content="{{ post.author.first_name }} {{ post.author.last_name }}">
 <meta property="og:image" content="{{ post.metaimg.url }}">
 <meta property="og:image:type" content="{{ post.metaimg_mimetype }}">
 <meta property="og:image:width" content="{{ post.metaimg.width }}">
@@ -29,7 +29,7 @@
   <img class="rounded-circle article-img" src="{{ post.author.profile.image.url }}" alt="" />
   <div class="media-body">
     <div class="article-metadata">
-      <nobr>John Solly <small class="text-muted">{{ post.date_posted|date:"F d, Y" }}</small>
+      <nobr>{{ post.author.first_name }} {{ post.author.last_name }} <small class="text-muted">{{ post.date_posted|date:"F d, Y" }}</small>
         {% if post.draft %} <span style="color:red"> (Draft)</span> {% endif %}
       </nobr>
       {% if post.author == user %}

--- a/django_project/tests/test_forms.py
+++ b/django_project/tests/test_forms.py
@@ -45,6 +45,8 @@ class TestForms(SetUp):
             data={
                 "username": "test",
                 "email": "example@test.com",
+                "first_name": "Tester",
+                "last_name": "Smith",
                 "password1": "Coff33cak3s!",
                 "password2": "Coff33cak3s!",
                 "secret_password": "African Swallows",

--- a/django_project/tests/test_views.py
+++ b/django_project/tests/test_views.py
@@ -202,6 +202,8 @@ class TestViews(SetUp):
         data = {
             "username": "test2",
             "email": "example2@test.com",
+            "first_name": "Tester2",
+            "last_name": "Smith",
             "password1": "Coff33cak3s!",
             "password2": "Coff33cak3s!",
             "secret_password": "African Swallows",

--- a/django_project/users/forms.py
+++ b/django_project/users/forms.py
@@ -7,12 +7,15 @@ from captcha.fields import CaptchaField
 
 class UserRegisterForm(UserCreationForm):
     email = forms.EmailField()
+    first_name = forms.CharField(max_length=50)
+    last_name = forms.CharField(max_length=50)
+
     secret_password = forms.CharField()
     captcha = CaptchaField()
 
     class Meta:
         model = User
-        fields = ["username", "email", "password1", "password2"]
+        fields = ["username", "first_name", "last_name", "email", "password1", "password2"]
 
 
 class UserUpdateForm(forms.ModelForm):


### PR DESCRIPTION
## What?
Add first_name and last_name to [User](https://docs.djangoproject.com/en/4.0/ref/contrib/auth/#django.contrib.auth.models.User) model.

replace all instances of "John Solly" and {{ post.author }} with {{ post.author.first_name post.author.last_name }}. In templates that use the Profile object instead of the User object, I replaced hardcoded "John Solly" values with {{ my_profile.user.first_name }} {{ my_profile.user.last_name }}

## Why?
It was cleaner to do this than remove the underscore from my username in the templates. It's also more rebust because the implementation will work if more authors are added to the site.

## Testing?