### PR TITLE
Simplify GitHub workflow

### DIFF
--- a/.github/workflows/django-test.yaml
+++ b/.github/workflows/django-test.yaml
@@ -9,17 +9,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-
-    strategy:
-      fail-fast: false
-      matrix:
-        language: ["javascript", "python"]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     env:
       SECRET_KEY: ${{secrets.SECRET_KEY}}
@@ -71,7 +60,21 @@ jobs:
           coverage run -m pytest django_project
           coverage report -m --skip-empty --skip-covered
 
-      # Initializes the CodeQL tools for scanning.
+  static_analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["javascript", "python"]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:

--- a/.github/workflows/django-test.yaml
+++ b/.github/workflows/django-test.yaml
@@ -75,6 +75,8 @@ jobs:
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
+      - uses: actions/checkout@v2
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
@@ -84,7 +86,7 @@ jobs:
         uses: github/codeql-action/analyze@v2
 
   deploy:
-    needs: build
+    needs: [build, static_analysis]
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to Linode


### PR DESCRIPTION
There's now seperate jobs for building and static analysis. The app won't deploy unless the build and test jobs complete.