### PR TITLE
Add Blog read time

### DIFF
--- a/django_project/blog/templates/blog/parts/posts.html
+++ b/django_project/blog/templates/blog/parts/posts.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load post_utils %}
 {% for post in posts %}
 
 {% if forloop.last %}
@@ -9,35 +10,35 @@
 
     <article>
       <a href="{% url 'post-detail' post.slug %}" aria-label='{{ post.title }}'>
-        <div class="card mb-5 shadow showhim">
+        <div class="card mb-5 shadow">
           <div class="row g-0">
             <div class="col-md-4 d-flex align-items-center">
               {% if post.metaimg %}
-              <img src="{{ post.metaimg.url }}" class="card-img-top" alt="{{ post.metaimg_alt_txt }}" />
+                <img src="{{ post.metaimg.url }}" class="card-img-top" alt="{{ post.metaimg_alt_txt }}" />
               {% endif %}
-
             </div>
             <div class="col-md-8">
-              <div class="card-body">
-                <div class="position-absolute top-50 start-50 showme">
-                  <img src="{% static 'svg/open-post-icon.svg' %}" width="24" height="24" alt="Open post">
-                  Open
+              <div class="card-body d-flex flex-column justify-content-between">
+                <div class="d-flex align-items-center mb-3">
+                  <h2 class="card-title fw-bolder ml-3">
+                    {{ post.title }}
+                    {% if post.draft %}
+                    <p id="draft">(Draft)</p>
+                    {% endif %}
+                  </h2>
                 </div>
-                <h2 class="card-title fw-bolder">
-                  {{ post.title }}
-                  {% if post.draft %}
-                  <p id="draft">(Draft)</p>
-                  {% endif %}
-                </h2>
-                <p class="card-text fs-6 mb-1">
-                  <small class="text-muted">
-                    {{ post.date_posted|date:"F d, Y" }} in {{ post.category|title }}</small>
-                </p>
+                <p class="fs-6 d-flex align-items-center">
+                  {{ post.date_posted|date:"F d, Y" }} in {{ post.category|title }}&nbsp;  
+                  <img src="{% static 'svg/clock.svg' %}" width="16" height="16" class="clock-icon" alt="Clock icon"> &nbsp {{ post.content|readtime }}
+              </p>
+                  <p class="card-text">
                 {{ post.snippet|safe }}
+              </p>
               </div>
             </div>
           </div>
         </div>
       </a>
     </article>
+    
     {% endfor %}

--- a/django_project/blog/templatetags/post_utils.py
+++ b/django_project/blog/templatetags/post_utils.py
@@ -1,0 +1,11 @@
+from django import template
+import readtime
+
+register = template.Library()
+
+
+def read(html):
+    return readtime.of_html(html)
+
+
+register.filter("readtime", read)

--- a/django_project/requirements/constraints.txt
+++ b/django_project/requirements/constraints.txt
@@ -12,6 +12,7 @@ cfgv==3.3.1
 charset-normalizer==2.1.1
 click==8.1.3
 coverage==7.0.1
+cssselect==1.2.0
 distlib==0.3.6
 Django==4.1.2
 django-ckeditor==6.4.2
@@ -37,6 +38,8 @@ identify==2.5.12
 idna==3.4
 iniconfig==1.1.1
 ipinfo==4.4.2
+lxml==4.9.2
+markdown2==2.4.6
 mccabe==0.7.0
 multidict==6.0.2
 mypy-extensions==0.4.3
@@ -51,9 +54,11 @@ psycopg2-binary==2.9.5
 pycodestyle==2.10.0
 pyflakes==3.0.1
 pyparsing==3.0.9
+pyquery==2.0.0
 pytest==7.2.0
 python-dotenv==0.21.0
 PyYAML==6.0
+readtime==2.0.0
 requests==2.28.1
 six==1.16.0
 soupsieve==2.3.2.post1

--- a/django_project/requirements/requirements.txt
+++ b/django_project/requirements/requirements.txt
@@ -22,5 +22,6 @@ pre-commit
 psycopg2-binary
 pytest
 python-dotenv
+readtime
 requests
 whitenoise

--- a/django_project/staticfiles/css/main.css
+++ b/django_project/staticfiles/css/main.css
@@ -14,6 +14,7 @@ Global Styles
 * {
   font-family: system-ui, Helvetica, Arial, sans-serif;
 }
+
 :root {
   --colorPrimary: white;
   --colorSecondary: black;
@@ -52,6 +53,7 @@ video {
 .footer-text {
   color: var(--colorPrimary);
 }
+
 #footer {
   color: var(--colorPrimary);
 }
@@ -101,7 +103,7 @@ body {
    Typeography
 ============= */
 
-.post-content > p:first-of-type::first-letter {
+.post-content>p:first-of-type::first-letter {
   font-size: 2rem;
   font-weight: 700;
 }
@@ -160,7 +162,6 @@ button a:hover {
 /* =============
    Cards
 ============= */
-
 
 img.card-img-top {
   height: 100%;
@@ -249,6 +250,7 @@ img.card-img-top {
 #github-calendar-title {
   color: var(--colorSecondary);
 }
+
 #accordion-wrapper {
   padding: 1rem;
   border-radius: 0.25rem;
@@ -305,7 +307,7 @@ a[href^="http"]::after {
   margin-left: 0.1rem;
   font-size: 0.9rem;
   font-weight: 900;
-} 
+}
 
 /* =============
    Media Queries
@@ -336,7 +338,6 @@ a[href^="http"]::after {
     box-shadow: 0 1rem 3rem var(--colorSecondary) !important;
     scale: 1.005;
   }
-}
 
   tr:hover {
     background-color: #ddd;
@@ -354,6 +355,7 @@ a[href^="http"]::after {
   .navbar-toggler-icon {
     background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%280, 0, 0, 0.55%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
   }
+
   body,
   .card,
   .form-control,
@@ -362,6 +364,7 @@ a[href^="http"]::after {
     background-color: rgb(18, 18, 18);
     border-color: var(--colorPrimary);
   }
+
   .testimonial-quote::before {
     color: hsla(229, 100%, 88%, 0.6);
   }
@@ -387,12 +390,15 @@ a[href^="http"]::after {
   footer::before {
     background-color: hsl(240, 4%, 16%);
   }
+
   #footer {
     color: var(--colorSecondary);
   }
+
   img {
     filter: brightness(0.8) contrast(1.2);
   }
+
   .card:not(#aboutMe):hover,
   #accordion-wrapper:hover {
     box-shadow: 0 1rem 3rem var(--colorPrimary) !important;

--- a/django_project/staticfiles/css/main.css
+++ b/django_project/staticfiles/css/main.css
@@ -161,17 +161,12 @@ button a:hover {
    Cards
 ============= */
 
+
 img.card-img-top {
   height: 100%;
   width: 100%;
 }
 
-.showme {
-  color: var(--colorPrimary);
-  opacity: 0;
-  transition: opacity 1.2s 0s;
-  letter-spacing: 2px;
-}
 
 #draft {
   color: red;
@@ -330,9 +325,6 @@ a[href^="http"]::after {
     transform: scaleX(1);
   }
 
-  .showhim:hover .showme {
-    opacity: 1;
-  }
 
   #accordion-wrapper:hover {
     box-shadow: 0 1rem 3rem var(--colorSecondary) !important;
@@ -344,6 +336,8 @@ a[href^="http"]::after {
     box-shadow: 0 1rem 3rem var(--colorSecondary) !important;
     scale: 1.005;
   }
+}
+
   tr:hover {
     background-color: #ddd;
   }
@@ -359,9 +353,6 @@ a[href^="http"]::after {
 
   .navbar-toggler-icon {
     background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%280, 0, 0, 0.55%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
-  }
-  .showme {
-    color: var(--colorSecondary);
   }
   body,
   .card,

--- a/django_project/staticfiles/svg/clock.svg
+++ b/django_project/staticfiles/svg/clock.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-clock-fill" viewBox="0 0 16 16">
+    <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM8 3.5a.5.5 0 0 0-1 0V9a.5.5 0 0 0 .252.434l3.5 2a.5.5 0 0 0 .496-.868L8 8.71V3.5z"/>
+  </svg>


### PR DESCRIPTION
- Added new dependency (readtime)
- Modify posts HTML fragment to include readtime. Add neat bootstrap clock icon!

The readtime is dynamically generated when the page loads using a new template tag, {% load post_utils %}. I believe this has slightly slower performance than if I stored the read time in the database with the post object, but I think this is a really clean implementation and it shouldn't hurt performance too bad.

In the future, it might make sense to store the reading time with the post object and move away from a template tag.