### PR TITLE
resolve typo in workflows.md, line 20

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -17,7 +17,7 @@
 ### Pull changes from github in prod
 
 ```bash
-$ source venv/bib/activate
+$ source venv/bin/activate
 $ python3 manage.py check --deploy
 $ python3 manage.py migrate # Don't need to makemigrations, because migrations are already in /migrations
 $ sudo service apache2 restart


### PR DESCRIPTION
**Description**

This pull request fixes a typo in the workflows.md file. The wrong code on line 20 has been corrected from source `venv/bib/activate` to source `venv/bin/activate`. This should resolve issue #269 

**Motivation and Context**
The typo in the code prevented the virtual environment from being activated correctly, causing issues with the project workflow. By fixing this typo, the project workflow can now be properly executed without errors.

**How Has This Been Tested?**
The fix has been tested locally by running the project workflow after applying the changes and ensuring that the virtual environment is correctly activated without any errors.

**Types of changes**
 Bug fix (non-breaking change which solves an issue)
 New feature (non-breaking change which adds functionality)
 Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist**
 I have read the contributing guidelines.
 My code follows the code style of this project.
 My change requires a change to the documentation.
 I have updated the documentation accordingly.
 I have added tests to cover my changes.
 All new and existing tests passed.

closes #269 