### PR TITLE
Migrate from os to pathlib

### DIFF
--- a/django_project/blog/storage.py
+++ b/django_project/blog/storage.py
@@ -1,10 +1,9 @@
-import os
 from urllib.parse import urljoin
-
 from django.conf import settings
 from django.core.files.storage import FileSystemStorage
+from pathlib import Path
 
 
 class CustomStorage(FileSystemStorage):
-    location = os.path.join(settings.MEDIA_ROOT, "django_ckeditor_5")
+    location = str(Path(settings.MEDIA_ROOT) / "django_ckeditor_5")
     base_url = urljoin(settings.MEDIA_URL, "django_ckeditor_5/")

--- a/django_project/blog/utils.py
+++ b/django_project/blog/utils.py
@@ -1,14 +1,14 @@
 from openai import Embedding, Completion
 from openai.embeddings_utils import distances_from_embeddings
 import pickle
-import os
+from pathlib import Path
 
 
 def load_pickle_file():
-    base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    file_path = os.path.join(base_dir, "blog", "df.pkl")
+    base_dir = Path(__file__).resolve().parent.parent
+    file_path = base_dir / "blog" / "df.pkl"
 
-    with open(file_path, "rb") as f:
+    with file_path.open("rb") as f:
         df = pickle.load(f)
 
     return df

--- a/django_project/django_project/settings/base_settings.py
+++ b/django_project/django_project/settings/base_settings.py
@@ -1,9 +1,10 @@
+from pathlib import Path
 import os
 from dotenv import load_dotenv
 
 load_dotenv()
 
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__ + "/../")))
+BASE_DIR = Path(__file__).resolve().parent.parent.parent  # Three levels up
 SECRET_KEY = os.environ["SECRET_KEY"]
 ALLOWED_HOSTS = os.environ["ALLOWED_HOSTS"].split(" ")
 
@@ -140,7 +141,7 @@ HANDLERS = {
     },
     "info_handler": {
         "class": "logging.handlers.RotatingFileHandler",
-        "filename": f"{BASE_DIR}/logs/blogthedata_info.log",
+        "filename": BASE_DIR / "logs/blogthedata_info.log",
         "mode": "a",
         "encoding": "utf-8",
         "formatter": "verbose",
@@ -150,7 +151,7 @@ HANDLERS = {
     },
     "error_handler": {
         "class": "logging.handlers.RotatingFileHandler",
-        "filename": f"{BASE_DIR}/logs/blogthedata_error.log",
+        "filename": BASE_DIR / "logs/blogthedata_error.log",
         "mode": "a",
         "formatter": "verbose",
         "level": "WARNING",
@@ -159,7 +160,7 @@ HANDLERS = {
     },
     "ezra_handler": {
         "class": "logging.handlers.RotatingFileHandler",
-        "filename": f"{BASE_DIR}/logs/ezra.log",
+        "filename": BASE_DIR / "logs/ezra.log",
         "mode": "a",
         "formatter": "simple",
         "level": "INFO",
@@ -232,18 +233,16 @@ USE_L10N = True
 USE_TZ = True
 
 
-STATIC_ROOT = os.path.join(BASE_DIR, "static")
+STATIC_ROOT = BASE_DIR / "static"
 STATIC_URL = "/static/"
 
 # Extra places for collectstatic to find static files.
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 # DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
-STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, "staticfiles"),
-]
+STATICFILES_DIRS = [str(BASE_DIR / "staticfiles")]
 
 MEDIA_URL = "/media/"
-MEDIA_ROOT = os.path.join(BASE_DIR, "media")
+MEDIA_ROOT = BASE_DIR / "media"
 
 CKEDITOR_UPLOAD_PATH = "uploads/"
 
@@ -421,6 +420,4 @@ CKEDITOR_5_CONFIGS = {
 
 
 CKEDITOR_5_FILE_STORAGE = "blog.storage.CustomStorage"
-CKEDITOR_5_CUSTOM_CSS = os.path.join(
-    STATIC_URL, "django_ckeditor_5/ckeditor_custom.css"
-)
+CKEDITOR_5_CUSTOM_CSS = STATIC_URL + "django_ckeditor_5/ckeditor_custom.css"

--- a/utilities/create_embeddings/process_posts.py
+++ b/utilities/create_embeddings/process_posts.py
@@ -1,5 +1,5 @@
 import pandas as pd
-import os
+from pathlib import Path
 import json
 
 
@@ -12,22 +12,22 @@ def remove_newlines(text):
 
 
 # This is the blogthedata directory if you cloned the repo
-BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+BASE_DIR = Path(__file__).resolve().parent.parent
 
 # Create a list to store the posts
 posts = []
 
 # Get all the JSON files in the exported_posts directory
-posts_path = os.path.join(BASE_DIR, "utilities/create_embeddings/exported_posts")
+posts_path = BASE_DIR / "utilities/create_embeddings/exported_posts"
 filepaths = [
-    os.path.join(posts_path, filename)
-    for filename in os.listdir(posts_path)
-    if filename.endswith(".json")
+    path
+    for path in posts_path.iterdir()
+    if path.is_file() and path.name.endswith(".json")
 ]
 
 # Loop through the list of file paths and read the JSON data
 for filepath in filepaths:
-    with open(filepath, "r") as f:
+    with filepath.open("r") as f:
         data = json.load(f)
 
         # Append the post fields to the list of posts
@@ -53,9 +53,7 @@ df["content"] = df.apply(
 )
 
 # Save the dataframe to a JSON file in the processed directory
-json_path = os.path.join(
-    BASE_DIR, "utilities/create_embeddings/processed", "processed_posts.json"
-)
+json_path = BASE_DIR / "utilities/create_embeddings/processed/processed_posts.json"
 df.to_json(json_path, orient="records")
 
 # Print the first few rows of the dataframe

--- a/utilities/create_embeddings/save_vectors_to_pickle.py
+++ b/utilities/create_embeddings/save_vectors_to_pickle.py
@@ -1,14 +1,14 @@
 import pandas as pd
 import numpy as np
 import json
-import os
 import pickle
 
-BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
-embeddings_path = os.path.join(
-    BASE_DIR, "utilities/create_embeddings/processed/embeddings.json"
-)
-df_pickle_path = os.path.join(BASE_DIR, "utilities/create_embeddings/processed/df.pkl")
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+embeddings_path = BASE_DIR / "utilities/create_embeddings/processed/embeddings.json"
+df_pickle_path = BASE_DIR / "utilities/create_embeddings/processed/df.pkl"
+
 
 # Load the JSON file as a list of dictionaries
 with open(embeddings_path, "r") as f:

--- a/utilities/create_embeddings/test_embeddings.py
+++ b/utilities/create_embeddings/test_embeddings.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import numpy as np
-import os
+from pathlib import Path
 import json
 from openai import Embedding, Completion
 from openai.embeddings_utils import distances_from_embeddings
@@ -25,7 +25,7 @@ def create_context(question, df, max_len=1800, size="ada"):
     cur_len = 0
 
     # Sort by distance and add the text to the context until the context is too long
-    for i, row in df.sort_values("distances", ascending=True).iterrows():
+    for _, row in df.sort_values("distances", ascending=True).iterrows():
         # Add the length of the text to the current length
         cur_len += row["n_tokens"] + 4
 
@@ -83,10 +83,8 @@ def answer_question(
 
 
 if __name__ == "__main__":
-    BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
-    embeddings_path = os.path.join(
-        BASE_DIR, "utilities/create_embeddings/processed/embeddings.json"
-    )
+    BASE_DIR = Path(__file__).resolve().parent.parent.parent  # Three levels up
+    embeddings_path = BASE_DIR / "utilities/create_embeddings/processed/embeddings.json"
 
     # Load the JSON file as a list of dictionaries
     with open(embeddings_path, "r") as f:

--- a/utilities/create_embeddings/tokenize_posts_and_create_embeddings.py
+++ b/utilities/create_embeddings/tokenize_posts_and_create_embeddings.py
@@ -1,6 +1,6 @@
 import tiktoken
 import pandas as pd
-import os
+from pathlib import Path
 import json
 import openai
 
@@ -9,13 +9,11 @@ import openai
 # Load the cl100k_base tokenizer which is designed to work with the ada-002 model
 tokenizer = tiktoken.get_encoding("cl100k_base")
 
-BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+BASE_DIR = Path(__file__).resolve().parent.parent.parent  # Three levels up
 
 # Load the JSON file as a list of dictionaries
 with open(
-    os.path.join(
-        BASE_DIR, "utilities/create_embeddings/processed/processed_posts.json"
-    ),
+    BASE_DIR / "utilities/create_embeddings/processed/processed_posts.json",
     "r",
 ) as f:
     data = json.load(f)
@@ -106,7 +104,5 @@ for row in df_shortened.iterrows():
 df_shortened["embeddings"] = embeddings
 
 # Save the dataframe to a JSON file in the processed directory
-json_path = os.path.join(
-    BASE_DIR, "utilities/create_embeddings/processed/embeddings.json"
-)
+json_path = BASE_DIR / "utilities/create_embeddings/processed/embeddings.json"
 df_shortened.to_json(json_path, orient="records")

--- a/utilities/create_embeddings/tokenize_posts_simple.py
+++ b/utilities/create_embeddings/tokenize_posts_simple.py
@@ -1,19 +1,17 @@
 import tiktoken
 import pandas as pd
-import os
+from pathlib import Path
 import json
 import matplotlib.pyplot as plt
 
 # Load the cl100k_base tokenizer which is designed to work with the ada-002 model
 tokenizer = tiktoken.get_encoding("cl100k_base")
 
-BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+BASE_DIR = Path(__file__).resolve().parent.parent.parent  # Three levels up
 
 # Load the JSON file as a list of dictionaries
 with open(
-    os.path.join(
-        BASE_DIR, "utilities/create_embeddings/processed/processed_posts.json"
-    ),
+    BASE_DIR / "utilities/create_embeddings/processed/processed_posts.json",
     "r",
 ) as f:
     data = json.load(f)


### PR DESCRIPTION
## Description

After reading [this blog post](https://t.co/FnyqBO0B7Z) on using Python to interact with the operating system, I realized I have been using the `os` module in a lot of places I could have been using `pathlib`

This PR replaces instances of `os` with `pathlib` where appropriate. 

## Changes Made

- [ ] Added new feature
- [ ] Fixed bug
- [x] Refactored code
- [ ] Other (please describe):

## Test Plan

All tests pass. App runs.
- Tested creating new posts with images (to test that image paths are resolving correctly)
- Visited various pages to ensure static assets are being loaded correctly.

## Checklist

- [x] I have read the [contributing guidelines](link_to_contributing_guidelines)
- [x] I have added tests to cover my changes, and they all pass in addition to the existing tests.
- [ ] I have added documentation for my changes.

## Additional Information

If you need any additional information relevant to this pull request, please include it here.
