### PR TITLE
chore: pin engines.node to 24.x (fleet Node consolidation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "description": "Dev tooling only (heroku CLI) — the app itself is Python/Django",
   "engines": {
-    "node": ">=24"
+    "node": "24.x"
   },
   "scripts": {
     "check:md": "bash scripts/lint-md.sh",


### PR DESCRIPTION
Standardizes `engines.node` on the pinned major form `24.x` (was `>=24`), part of a fleet-wide Node-version consolidation across `~/code`.

**Why:** the `>=24` floor permits future majors (25, 26…), which could silently diverge from `.nvmrc` (`24`) and the Lambda `nodejs24.x` runtime. Pinning `24.x` makes `package.json` agree with the other surfaces and gives one Node major everywhere. No runtime change — `.nvmrc`/CI already resolve to 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)