### PR TITLE
test(users): add password_reset_confirm view + URL tests

### DIFF
--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -31,6 +31,7 @@ from users.views import (
     MyLogoutView,
     MyPasswordResetView,
     MyPasswordResetDoneView,
+    MyPasswordResetConfirmView,
     MyPasswordResetCompleteView,
 )
 
@@ -119,8 +120,14 @@ class TestUrls(SetUp):
             get_url("password_reset_done").func.view_class, MyPasswordResetDoneView
         )
 
-    # def test_password_reset_confirm_url_is_resolved(self): #TODO
-    #     self.assertEqual(get_url("password_reset_confirm").func.view_class, MyPasswordResetConfirmView)
+    def test_password_reset_confirm_url_is_resolved(self):
+        # The route requires uidb64/token kwargs, so reverse() needs them
+        # (get_url() cannot be used here). Mirror the comment-update pattern.
+        url = reverse(
+            "password_reset_confirm",
+            kwargs={"uidb64": "uid", "token": "reset-token"},
+        )
+        self.assertEqual(resolve(url).func.view_class, MyPasswordResetConfirmView)
 
     def test_password_reset_complete_url_is_resolved(self):
         self.assertEqual(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -17,6 +17,9 @@ from unittest.mock import patch
 from django.urls import reverse
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.contrib.auth.models import User
+from django.contrib.auth.tokens import default_token_generator
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
 
 
 class TestViews(SetUp):
@@ -494,8 +497,26 @@ class TestViews(SetUp):
         response = self.client.get(reverse("password_reset_done"))
         self.assertResponseAndTemplate(response, "users/password_reset_done.html")
 
-    # def test_password_reset_confirm_view(self):
-    #     # TODO
+    def test_password_reset_confirm_view(self):
+        # A valid GET carries a uidb64/token pair; Django's confirm view
+        # validates the token, stashes it in the session, and redirects to the
+        # set-password URL, which renders the same confirm template. follow=True
+        # is required: the per-test self.client does not follow redirects.
+        uidb64 = urlsafe_base64_encode(force_bytes(self.admin_user.pk))
+        token = default_token_generator.make_token(self.admin_user)
+        response = self.client.get(
+            reverse(
+                "password_reset_confirm",
+                kwargs={"uidb64": uidb64, "token": token},
+            ),
+            follow=True,
+        )
+        self.assertResponseAndTemplate(response, "users/password_reset_confirm.html")
+        # The template renders at 200 even for an invalid link, so assert the
+        # valid-token signal explicitly: the initial GET must 302 to the
+        # set-password step and the final view must report a valid link.
+        self.assertEqual(len(response.redirect_chain), 1)
+        self.assertTrue(response.context["validlink"])
 
     def test_password_reset_complete(self):
         response = self.client.get(reverse("password_reset_complete"))


### PR DESCRIPTION
## Summary

Implements the two commented-out test stubs from #507 and removes the stubs.

- **`tests/test_views.py` — `test_password_reset_confirm_view`**: generates a valid `uidb64`/`token` for the seeded `admin` user (`urlsafe_base64_encode(force_bytes(pk))` + `default_token_generator`), GETs the `password_reset_confirm` URL with `follow=True`, and asserts the confirm template plus the valid-token signal. The template renders at 200 even for an *invalid* link (`validlink=False`), so a bare template assertion would pass on the failure path too — the test additionally asserts the initial GET produced one redirect (302 → `set-password`) and that `response.context["validlink"]` is `True`, pinning the valid-token branch.
- **`tests/test_urls.py` — `test_password_reset_confirm_url_is_resolved`**: uses `reverse()` + `resolve()` with dummy `uidb64`/`token` kwargs (the route requires them, so the `get_url()` helper can't be used) and asserts `.func.view_class == MyPasswordResetConfirmView`. Adds the missing import.

## Test plan

- [x] `pytest tests` — 107 passed (full suite, no regressions)
- [x] Full pre-push gate reproduced locally under gate env (ruff, yaml lint, collectstatic, migrate, pytest+coverage) — green
- [x] Verified the valid-token path empirically: valid token → 302 → `set-password` → 200 with `validlink=True`; invalid token → 200 with `validlink=False`

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)