### PR TITLE
feat(blog): migrate AI chatbot and authoring helpers to Gemini

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ DB_PASSWORD=my_password
 DB_HOST=localhost
 DB_PORT=5432
 USE_SQLITE=True # By default all the commands (e.g. migrate will point to a .sqlite file)
+GEMINI_API_KEY=  # Google Gemini key for the Ezra chatbot and GPT authoring helpers
 LOGGING=True  # Creates log files in app/logs
 GIT_TOKEN=  # Used for Coveralls test coverage
 DEBUG=True  # Set to False in production

--- a/blog/gemini.py
+++ b/blog/gemini.py
@@ -1,0 +1,67 @@
+"""Thin adapter over the Google Gemini API.
+
+Both the RAG chatbot (`blog/utils.py`) and the authoring helpers
+(`blog/views.py`) go through these two functions so the provider lives in one
+place. The client is built lazily so importing this module never requires a key
+(tests patch `embed_text` / `generate_text` and never construct a client).
+"""
+
+import os
+
+from google import genai
+from google.genai import types
+
+# gemini-embedding-001 defaults to 3072 dims; 1536 is the same value stored in
+# blog/df.pkl by the regenerate_embeddings command. Query and stored embeddings
+# MUST share this dimensionality or cosine distance is meaningless.
+EMBEDDING_MODEL = "gemini-embedding-001"
+EMBEDDING_DIM = 1536
+GENERATION_MODEL = "gemini-2.5-flash"
+
+_client = None
+
+
+def get_client():
+    global _client
+    if _client is None:
+        _client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+    return _client
+
+
+def embed_text(text: str) -> list[float]:
+    response = get_client().models.embed_content(
+        model=EMBEDDING_MODEL,
+        contents=text,
+        config=types.EmbedContentConfig(output_dimensionality=EMBEDDING_DIM),
+    )
+    return response.embeddings[0].values
+
+
+def generate_text(prompt: str, max_output_tokens: int, temperature: float = 0.5) -> str:
+    """Single-shot text generation with thinking disabled.
+
+    Thinking is off (`thinking_budget=0`) because every caller wants a short,
+    deterministic string and the reasoning tokens would otherwise consume the
+    tight `max_output_tokens` budget and return empty text.
+    """
+    response = get_client().models.generate_content(
+        model=GENERATION_MODEL,
+        contents=prompt,
+        config=types.GenerateContentConfig(
+            max_output_tokens=max_output_tokens,
+            temperature=temperature,
+            thinking_config=types.ThinkingConfig(thinking_budget=0),
+        ),
+    )
+    text = response.text
+    if not text or not text.strip():
+        # A null/empty response means the candidate carried no text — safety
+        # block, recitation, or MAX_TOKENS with nothing emitted. Fail loud so
+        # the caller's logger fires instead of rendering a blank answer.
+        candidate = (response.candidates or [None])[0]
+        raise RuntimeError(
+            "Gemini returned no text "
+            f"(finish_reason={getattr(candidate, 'finish_reason', None)}, "
+            f"block_reason={getattr(response.prompt_feedback, 'block_reason', None)})"
+        )
+    return text.strip()

--- a/blog/management/commands/regenerate_embeddings.py
+++ b/blog/management/commands/regenerate_embeddings.py
@@ -1,0 +1,45 @@
+"""Rebuild blog/df.pkl with Gemini embeddings.
+
+The chatbot's retrieval compares a query embedding against the per-chunk
+embeddings stored in blog/df.pkl. Those were originally produced by OpenAI's
+text-embedding-ada-002 (1536-dim); after moving to Gemini they must be
+re-embedded with gemini-embedding-001 so query and corpus live in one vector
+space. This re-embeds the existing `content` column in place, leaving the chunk
+text and n_tokens untouched.
+"""
+
+import time
+
+from django.core.management.base import BaseCommand
+
+from blog.gemini import embed_text
+from blog.utils import load_pickle_file
+from pathlib import Path
+
+# gemini-embedding-001 free tier caps at ~100 requests/minute; a small gap
+# keeps the ~300-chunk rebuild under that ceiling without special-casing 429s.
+_THROTTLE_SECONDS = 0.7
+
+
+class Command(BaseCommand):
+    help = "Re-embed blog/df.pkl chunks with the current Gemini embedding model."
+
+    def handle(self, *args, **kwargs):
+        df = load_pickle_file()
+        total = len(df)
+        self.stdout.write(
+            self.style.SUCCESS(f"Re-embedding {total} chunks with Gemini...")
+        )
+
+        embeddings = []
+        for i, content in enumerate(df["content"], start=1):
+            embeddings.append(embed_text(content))
+            if i % 25 == 0 or i == total:
+                self.stdout.write(f"  {i}/{total}")
+            time.sleep(_THROTTLE_SECONDS)
+
+        df["embeddings"] = embeddings
+
+        out_path = Path(__file__).resolve().parents[3] / "blog" / "df.pkl"
+        df.to_pickle(out_path)
+        self.stdout.write(self.style.SUCCESS(f"Wrote {total} embeddings to {out_path}"))

--- a/blog/utils.py
+++ b/blog/utils.py
@@ -1,4 +1,3 @@
-from openai import Embedding, Completion
 from typing import List
 from scipy import spatial
 import pickle
@@ -7,6 +6,7 @@ from sklearn.feature_extraction.text import TfidfVectorizer, ENGLISH_STOP_WORDS
 from sklearn.metrics.pairwise import cosine_similarity
 import numpy as np
 from .models import Post, Similarity
+from .gemini import embed_text, generate_text
 import string
 import re
 
@@ -42,15 +42,13 @@ def distances_from_embeddings(
     return distances
 
 
-def create_context(question, df, max_len=1800, size="ada"):
+def create_context(question, df, max_len=1800):
     """
     Create a context for a question by finding the most similar context from the dataframe
     """
 
     # Get the embeddings for the question
-    q_embeddings = Embedding.create(input=question, engine="text-embedding-ada-002")[
-        "data"
-    ][0]["embedding"]
+    q_embeddings = embed_text(question)
 
     # Get the distances from the embeddings
     df["distances"] = distances_from_embeddings(
@@ -77,13 +75,9 @@ def create_context(question, df, max_len=1800, size="ada"):
 
 
 def answer_question(
-    model="gpt-3.5-turbo-instruct",
     question=None,
     max_len=1800,
-    size="ada",
-    debug=False,
     max_tokens=150,
-    stop_sequence=None,
     df=global_df,
 ):
     """
@@ -93,25 +87,14 @@ def answer_question(
         question,
         df,
         max_len=max_len,
-        size=size,
     )
-    # If debug, print the raw model response
-    # if debug:
-    #     print("Context:\n" + context)
-    #     print("\n\n")
 
-    # Create a completions using the question and context
-    response = Completion.create(
-        prompt=f"Answer the question based on the context below, and if the question can't be answered based on the context, say \"I don't know\"\n\nContext: {context}\n\n---\n\nQuestion: {question}\nAnswer:",
-        temperature=0,
-        max_tokens=max_tokens,
-        top_p=1,
-        frequency_penalty=0,
-        presence_penalty=0,
-        stop=stop_sequence,
-        model=model,
+    prompt = (
+        "Answer the question based on the context below, and if the question "
+        "can't be answered based on the context, say \"I don't know\"\n\n"
+        f"Context: {context}\n\n---\n\nQuestion: {question}\nAnswer:"
     )
-    return response["choices"][0]["text"].strip()
+    return generate_text(prompt, max_output_tokens=max_tokens, temperature=0)
 
 
 def preprocess_text(text: str) -> str:

--- a/blog/views.py
+++ b/blog/views.py
@@ -1,12 +1,10 @@
 # Standard library imports
 import html
 import logging
-import os
 from datetime import datetime
 import shutil
 
 # Third-party imports
-import openai
 import psycopg
 import psutil
 
@@ -35,10 +33,10 @@ from django.views.generic import (
 from .models import Post, Category, Comment
 from .forms import PostForm, CommentForm
 from .utils import answer_question
+from .gemini import generate_text
 from users.models import User
 
 
-openai.api_key = os.environ.get("OPENAI_API_KEY")
 ez_logger = logging.getLogger("ezra_logger")
 
 _LOG_PREVIEW_MAX_CHARS = 500
@@ -123,7 +121,7 @@ class StatusView(TemplateView):
         # Get the disk usage
         disk_usage_info = shutil.disk_usage("/")
         total, used, free = disk_usage_info
-        disk_usage = f"{used // (2 ** 30)}GB / {total // (2 ** 30)}GB"
+        disk_usage = f"{used // (2**30)}GB / {total // (2**30)}GB"
 
         context = {
             "title": "Status | Blogthedata.com",
@@ -157,7 +155,9 @@ class AllPostsView(ListView):
         context = super().get_context_data(*args, **kwargs)
         context["url"] = self.request.path
         context["title"] = "All Posts | Blogthedata.com"
-        context["description"] = "Explore insightful articles on geospatial solutions, cloud-native tech, and more from a seasoned software engineer. Dive into the latest posts now!"
+        context["description"] = (
+            "Explore insightful articles on geospatial solutions, cloud-native tech, and more from a seasoned software engineer. Dive into the latest posts now!"
+        )
         return context
 
 
@@ -181,9 +181,9 @@ class HomeView(ListView):
         context = super().get_context_data(*args, **kwargs)
         context["url"] = self.request.path
         context["title"] = "Solly's Blog | Blogthedata.com"
-        context[
-            "description"
-        ] = "Gain productivity and stay informed on the latest geospatial web dev techniques with blog posts from a geospatial software engineer. Get valuable insights."
+        context["description"] = (
+            "Gain productivity and stay informed on the latest geospatial web dev techniques with blog posts from a geospatial software engineer. Get valuable insights."
+        )
         return context
 
 
@@ -206,9 +206,9 @@ class CategoryView(ListView):
         context["category"] = category
         context["url"] = self.request.path
         context["title"] = f"{category.name.title()} | Blogthedata.com"
-        context[
-            "description"
-        ] = f"Get tips and insights on {category.name.title()} from a geospatial engineer. Read the latest blog posts and stay up-to-date on the latest industry trends."
+        context["description"] = (
+            f"Get tips and insights on {category.name.title()} from a geospatial engineer. Read the latest blog posts and stay up-to-date on the latest industry trends."
+        )
         return context
 
     def get_template_names(self):
@@ -256,9 +256,9 @@ class SearchView(ListView):
         context["searched"] = self.request.GET.get("searched")
         context["num_results"] = self.get_queryset().count()
         context["title"] = f"Search Results for {self.request.GET.get('searched')}"
-        context[
-            "description"
-        ] = f"Search results for {self.request.GET.get('searched')}"
+        context["description"] = (
+            f"Search results for {self.request.GET.get('searched')}"
+        )
         return context
 
 
@@ -282,7 +282,7 @@ class PostDetailView(DetailView):
         context["description"] = self.object.metadesc
         context["comment_form"] = CommentForm()
         context["related_posts"] = related_posts
-        
+
         if self.object.metaimg:
             try:
                 context["metaimg_url"] = self.object.metaimg.url
@@ -435,7 +435,9 @@ class CommentDeleteView(UserPassesTestMixin, View):
         if self.request.htmx:
             if post.comments.count() == 0:
                 oob_swap_command = '<div hx-swap-oob="true" id="no-comments-message">No comments yet</div>'
-                return HttpResponse(oob_swap_command, status=200, reason="Comment deleted successfully")
+                return HttpResponse(
+                    oob_swap_command, status=200, reason="Comment deleted successfully"
+                )
             return HttpResponse(status=200, reason="Comment deleted successfully")
         return redirect("post-detail", slug=post.slug)
 
@@ -444,12 +446,7 @@ def generate_gpt_input_value(request):
     def get_safe_completion(prompt, max_tokens, trigger):
         try:
             completion = (
-                openai.Completion.create(
-                    model="gpt-3.5-turbo-instruct",
-                    prompt=prompt,
-                    max_tokens=max_tokens,
-                    temperature=0.5,
-                )["choices"][0]["text"]
+                generate_text(prompt, max_output_tokens=max_tokens, temperature=0.5)
                 .replace("\n", "")
                 .replace('"', "")
             )
@@ -528,6 +525,12 @@ def answer_question_with_GPT(request):
             },
         )
         raise
-    response = f"<div class='messages__item messages__item--bot'>{completion}</div>"
+    # Escape the model output before reflecting it into HTML: the answer is
+    # driven by untrusted input (the question and RAG context from post bodies),
+    # so a prompt-injection payload must not render as live markup.
+    safe_completion = html.escape(completion)
+    response = (
+        f"<div class='messages__item messages__item--bot'>{safe_completion}</div>"
+    )
 
     return HttpResponse(response)

--- a/docs/heroku_deploy.md
+++ b/docs/heroku_deploy.md
@@ -39,8 +39,8 @@ heroku config:set AWS_ACCESS_KEY_ID=<your-aws-key> -a <your_app_name>
 heroku config:set AWS_SECRET_ACCESS_KEY=<your-aws-secret> -a <your_app_name>
 heroku config:set AWS_STORAGE_BUCKET_NAME=<your-bucket-name> -a <your_app_name>
 
-# OpenAI
-heroku config:set OPENAI_API_KEY=<your-openai-key> -a <your_app_name>
+# Google Gemini
+heroku config:set GEMINI_API_KEY=<your-gemini-key> -a <your_app_name>
 ```
 
 ## Database Setup

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ django-htmlmin==0.11.0
 ## GPT Bot dependencies (Distances From Embeddings)
 matplotlib==3.10.9
 numpy==2.3.5
-openai==1.51.0
+google-genai==2.10.0
 pandas==3.0.3
 plotly==6.8.0
 scikit-learn==1.7.2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -35,37 +35,42 @@ class TestUtils(TestCase, MiddlewareMixin):
             self.assertIn(keyword, tokens)
 
     @patch("blog.utils.load_pickle_file")
-    @patch("openai.Embedding.create")
-    def test_create_context(self, mock_create, mock_load_pickle_file):
+    @patch("blog.utils.embed_text")
+    def test_create_context(self, mock_embed_text, mock_load_pickle_file):
         mock_load_pickle_file.return_value = pd.DataFrame(
             {
                 "text": ["The capital of the United States is Washington, D.C."],
-                "embeddings": [np.random.random(512)],
+                "embeddings": [np.random.random(1536)],
                 "n_tokens": [10],
                 "content": ["The capital of the United States is Washington, D.C."],
             }
         )
-        mock_create.return_value = {"data": [{"embedding": np.random.random(512)}]}
+        mock_embed_text.return_value = np.random.random(1536)
         context = create_context(
             "What is the capital of the United States of America?",
             mock_load_pickle_file.return_value,
         )
         self.assertIsInstance(context, str)
+        # The selected context must actually carry the source row's content,
+        # not just be some string — otherwise the retrieval logic is untested.
+        self.assertIn("Washington, D.C.", context)
 
     @patch("blog.utils.load_pickle_file")
-    @patch("openai.Embedding.create")
-    def test_create_context_exceed_max_len(self, mock_create, mock_load_pickle_file):
+    @patch("blog.utils.embed_text")
+    def test_create_context_exceed_max_len(
+        self, mock_embed_text, mock_load_pickle_file
+    ):
         mock_load_pickle_file.return_value = pd.DataFrame(
             {
                 "text": ["The capital of the United States is Washington, D.C."]
                 * 200,  # Multiply by 200 to exceed max_len
-                "embeddings": [np.random.random(512)] * 200,
+                "embeddings": [np.random.random(1536)] * 200,
                 "n_tokens": [10] * 200,
                 "content": ["The capital of the United States is Washington, D.C."]
                 * 200,
             }
         )
-        mock_create.return_value = {"data": [{"embedding": np.random.random(512)}]}
+        mock_embed_text.return_value = np.random.random(1536)
         context = create_context(
             "What is the capital of the United States of America?",
             mock_load_pickle_file.return_value,
@@ -73,27 +78,25 @@ class TestUtils(TestCase, MiddlewareMixin):
         self.assertIsInstance(context, str)
         self.assertTrue(len(context.split(" ")) <= 1800)
 
-    @patch("openai.Embedding.create")
-    @patch("openai.Completion.create")
+    @patch("blog.utils.embed_text")
+    @patch("blog.utils.generate_text")
     @patch("blog.utils.load_pickle_file")
     def test_answer_question(
-        self, mock_load_pickle_file, mock_create, mock_embedding_create
+        self, mock_load_pickle_file, mock_generate_text, mock_embed_text
     ):
         df = pd.DataFrame(
             {
                 "text": ["The capital of the United States is Washington, D.C."],
                 "embeddings": [
-                    [0.0 for _ in range(512)]
-                ],  # Assuming embeddings are 512-dimensional
+                    np.random.random(1536)
+                ],  # gemini-embedding-001 is 1536-dimensional
                 "n_tokens": [10],  # Assuming the text has 10 tokens
                 "content": ["The capital of the United States is Washington, D.C."],
             }
         )
         mock_load_pickle_file.return_value = df
-        mock_create.return_value = {"choices": [{"text": "The mocked answer"}]}
-        mock_embedding_create.return_value = {
-            "data": [{"embedding": [0.0 for _ in range(512)]}]
-        }
+        mock_generate_text.return_value = "The mocked answer"
+        mock_embed_text.return_value = list(np.random.random(1536))
 
         answer = answer_question(
             question="What is the capital of the United States of America?", df=df

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -373,7 +373,6 @@ class TestViews(SetUp):
     #     response = self.client.get(category_url, {"page": 2})
     #     self.assertTrue(response.context["page_obj"].has_previous())
 
-
     def test_search_view_blank(self):
         response = self.client.get(reverse("blog-search"))
         self.assertResponseAndTemplate(response, "blog/search_posts.html")
@@ -548,9 +547,9 @@ class TestViews(SetUp):
         response = self.client.get(reverse("security-pgp-key-txt"))
         self.assertEqual(response.status_code, 200)
 
-    @patch("openai.Completion.create")
-    def test_generate_gpt_input_title(self, mock_create):
-        mock_create.return_value = {"choices": [{"text": "mocked response"}]}
+    @patch("blog.views.generate_text")
+    def test_generate_gpt_input_title(self, mock_generate_text):
+        mock_generate_text.return_value = "mocked response"
         headers = {"HTTP_HX-Trigger": "generate-title"}
         response = self.client.post(
             "/generate-with-gpt/", data={"content": "my test blog content"}, **headers
@@ -568,9 +567,11 @@ class TestViews(SetUp):
             "No content found in the post content field", response.content.decode()
         )
 
-    @patch("openai.Completion.create")
-    def test_generate_gpt_input_slug(self, mock_create):
-        mock_create.return_value = {"choices": [{"text": "mocked-response"}]}
+    @patch("blog.views.generate_text")
+    def test_generate_gpt_input_slug(self, mock_generate_text):
+        # Return an un-slugified string so the slug branch's lowercase +
+        # hyphenate transform is what produces the asserted value.
+        mock_generate_text.return_value = "Mocked Response"
         headers = {"HTTP_HX-Trigger": "generate-slug"}
         response = self.client.post(
             "/generate-with-gpt/",
@@ -592,9 +593,9 @@ class TestViews(SetUp):
             "No content found in the post title field", response.content.decode()
         )
 
-    @patch("openai.Completion.create")
-    def test_generate_gpt_input_metadesc(self, mock_create):
-        mock_create.return_value = {"choices": [{"text": "mocked response"}]}
+    @patch("blog.views.generate_text")
+    def test_generate_gpt_input_metadesc(self, mock_generate_text):
+        mock_generate_text.return_value = "mocked response"
         headers = {"HTTP_HX-Trigger": "generate-metadesc"}
         response = self.client.post(
             "/generate-with-gpt/",
@@ -616,13 +617,11 @@ class TestViews(SetUp):
             "No content found in the post content field", response.content.decode()
         )
 
-    @patch("openai.Embedding.create")
-    @patch("openai.Completion.create")
-    def test_answer_question_with_gpt(
-        self, mock_completion_create, mock_embedding_create
-    ):
-        mock_embedding_create.return_value = {"data": [{"embedding": [0.1] * 1536}]}
-        mock_completion_create.return_value = {"choices": [{"text": "mocked response"}]}
+    @patch("blog.utils.embed_text")
+    @patch("blog.utils.generate_text")
+    def test_answer_question_with_gpt(self, mock_generate_text, mock_embed_text):
+        mock_embed_text.return_value = [0.1] * 1536
+        mock_generate_text.return_value = "mocked response"
         response = self.client.post(
             "/answer-with-gpt/", data={"question-text-area": "Test question?"}
         )


### PR DESCRIPTION
Ports the Ezra chatbot (`/answer-with-gpt/`) and GPT authoring helpers (`/generate-with-gpt/`) off the removed pre-1.0 OpenAI API (`openai.Completion`/`Embedding`, deprecated `gpt-3.5-turbo-instruct`) to Google Gemini.

## What changed
- **`blog/gemini.py`** — new thin adapter (lazy client): `embed_text` (gemini-embedding-001, 1536-dim), `generate_text` (gemini-2.5-flash, thinking disabled for short deterministic output). Fails loud on empty/blocked responses.
- **`blog/utils.py` / `blog/views.py`** — RAG retrieval + both AI endpoints rewired through the adapter; dropped ada-era params. Chatbot output now HTML-escaped before reflection (XSS hardening on the untrusted LLM sink).
- **`blog/df.pkl`** — 288-chunk corpus re-embedded with Gemini via the new `regenerate_embeddings` management command so query + corpus share one vector space.
- **deps** — `openai==1.51.0` → `google-genai==2.10.0`. `.env.example` + `docs/heroku_deploy.md` updated to `GEMINI_API_KEY`.
- **tests** — mocks migrated to the Gemini adapter; three weak assertions strengthened.

## Verification
- 107 tests pass; ruff clean.
- Chatbot verified answering live locally via Gemini (grounded PEP 8 answer, 200).
- Prod `GEMINI_API_KEY` already set on Heroku.

🤖 Generated with [Claude Code](https://claude.com/claude-code)