### PR TITLE
docs(heroku): document exporting prod DB and restoring locally

### DIFF
--- a/docs/heroku_deploy.md
+++ b/docs/heroku_deploy.md
@@ -187,3 +187,76 @@ Important Notes:
   dig <your_app_name>.com
   dig www.<your_app_name>.com
   ```
+
+## Export prod database and restore locally
+
+Production runs on Heroku Postgres, so you cannot restore a prod dump into the
+default local SQLite database. Restore into a **local PostgreSQL** instance and
+point Django at it with `USE_SQLITE=False`.
+
+The Heroku CLI ships as a dev dependency in this repo, so the commands below
+call it through `npx heroku` (run `npm install` first if you haven't).
+
+1. Make sure a local PostgreSQL server is running and create an empty database
+   to restore into:
+
+   ```bash
+   createdb blogthedata_local
+   ```
+
+2. Point your local `.env.local` at that database (see `.env.example` for the
+   full list). The relevant variables are:
+
+   ```bash
+   USE_SQLITE=False
+   DB_ENGINE=django.db.backends.postgresql
+   DB_NAME=blogthedata_local
+   DB_USER=<your_local_pg_user>
+   DB_PASS=<your_local_pg_password>
+   DB_HOST=localhost
+   DB_PORT=5432
+   ```
+
+3. Capture a fresh backup of the production database:
+
+   ```bash
+   npx heroku pg:backups:capture -a <your_app_name>
+   ```
+
+4. Download the backup. This writes a `latest.dump` file to your current
+   directory:
+
+   ```bash
+   npx heroku pg:backups:download -a <your_app_name>
+   ```
+
+5. Restore the dump into your local database. `--clean` drops existing objects
+   first, and `--no-acl --no-owner` skips the Heroku-specific roles and grants
+   that don't exist locally:
+
+   ```bash
+   pg_restore --verbose --clean --no-acl --no-owner \
+     -h localhost -U <your_local_pg_user> -d blogthedata_local latest.dump
+   ```
+
+6. Apply any migrations that are newer than the production snapshot, then start
+   the app to confirm the data loaded:
+
+   ```bash
+   python manage.py migrate
+   python manage.py runserver
+   ```
+
+7. Remove the dump when you're done — it contains production data:
+
+   ```bash
+   rm latest.dump
+   ```
+
+> **Shortcut:** `npx heroku pg:pull` combines steps 3-5 by streaming the prod
+> database straight into a new local one (the target database must **not**
+> already exist):
+>
+> ```bash
+> npx heroku pg:pull DATABASE_URL blogthedata_local -a <your_app_name>
+> ```


### PR DESCRIPTION
Fills in the previously-empty **"Export prod database and restore locally"** section of `docs/heroku_deploy.md`.

The bare `TODO` was migrated out of the doc into this issue (#509). This adds the real steps, grounded in the repo's actual settings:

- Production runs Heroku Postgres; local dev defaults to SQLite (`USE_SQLITE=True`). A Postgres dump can't be restored into SQLite, so the doc restores into a **local PostgreSQL** target with `USE_SQLITE=False` and the `DB_*` vars from `.env.example`.
- Uses the repo's `npx heroku` CLI (Heroku ships as a devDependency here) for `pg:backups:capture` / `pg:backups:download`, then `pg_restore --clean --no-acl --no-owner`.
- Includes the `npx heroku pg:pull` one-shot shortcut and a reminder to delete the `latest.dump` (contains prod data).

Docs-only change.

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)