### PR TITLE
fix(blog): close out open issues — chatbox textarea reset, dark-mode text color

### DIFF
--- a/blog/templates/blog/parts/chatbox.html
+++ b/blog/templates/blog/parts/chatbox.html
@@ -30,7 +30,7 @@
                     {% csrf_token %}
                     <div class="chatbox__input-container">
                         <textarea name="question-text-area" id="question-text-area" placeholder="Send a message..."
-                            hx-trigger="keyup[key === 'Enter' && !shiftKey]" hx-post="/answer-with-gpt/"
+                            hx-trigger="keyup[key === 'Enter' && !shiftKey && target.value.trim() !== '']" hx-post="/answer-with-gpt/"
                             hx-include="#question-text-area" hx-target=".chatbox__messages"
                             hx-swap="afterbegin"></textarea>
                         <button class="chatbox__send--footer send__button" hx-post="/answer-with-gpt/"

--- a/blog/views.py
+++ b/blog/views.py
@@ -510,6 +510,14 @@ def generate_gpt_input_value(request):
 @csrf_exempt
 def answer_question_with_GPT(request):
     question = request.POST.get("question-text-area", "")
+    # Guard the paid LLM call: an empty question (send-button click or a
+    # direct POST — the Enter path is already filtered client-side) gets a
+    # canned reply instead of a completion request.
+    if not question.strip():
+        return HttpResponse(
+            "<div class='messages__item messages__item--bot'>"
+            "Please type a question first.</div>"
+        )
     ez_logger.info(
         "GPT question received",
         extra={"question_preview": _bounded_log_preview(question)},

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -58,6 +58,9 @@ body {
   margin: 0;
   line-height: 1.6;
   overflow-x: hidden;
+  /* Inherited default so text outside the :is() element list below (divs,
+     spans, bare text in post content) stays readable in dark mode. */
+  color: var(--secondary-color);
 }
 
 body,
@@ -863,9 +866,7 @@ h2 {
   .word-count,
   label,
   input,
-  form,
-
-) {
+  form) {
   color: var(--secondary-color);
 }
 

--- a/static/js/chatbox.js
+++ b/static/js/chatbox.js
@@ -21,20 +21,18 @@ document.addEventListener("DOMContentLoaded", () => {
         textArea.style.height = `${textArea.scrollHeight}px`;
       });
 
+      // Keep the newline out of the textarea so an empty Enter can't grow it;
+      // sending stays on keyup so htmx reads the value before it is cleared.
+      textArea.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" && !event.shiftKey) {
+          event.preventDefault();
+        }
+      });
+
       textArea.addEventListener("keyup", ({ key, shiftKey }) => {
         if (key === "Enter" && !shiftKey) {
           this.onSendButton();
         }
-      });
-
-      const observer = new MutationObserver(() => {
-        textArea.style.height = "auto";
-      });
-
-      observer.observe(textArea, {
-        childList: true,
-        subtree: true,
-        characterData: true,
       });
     }
 
@@ -49,13 +47,12 @@ document.addEventListener("DOMContentLoaded", () => {
     onSendButton() {
       const textField = this.chatBox.querySelector("#question-text-area");
       const text = textField.value.trim();
-      if (text === "" || text === "\n") {
+      textField.value = "";
+      textField.style.height = "auto";
+      if (text === "") {
         return;
       }
       this.updateChatText(text);
-      textField.value = "";
-      textField.style.height = "auto";
-      textField.dispatchEvent(new Event("input"));
     }
 
     updateChatText(text) {

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -627,3 +627,16 @@ class TestViews(SetUp):
         )
         self.assertEqual(response.status_code, 200)
         self.assertIn("mocked response", response.content.decode())
+
+    @patch("blog.utils.embed_text")
+    @patch("blog.utils.generate_text")
+    def test_answer_question_with_gpt_empty_question_skips_openai(
+        self, mock_generate_text, mock_embed_text
+    ):
+        response = self.client.post(
+            "/answer-with-gpt/", data={"question-text-area": "   \n"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Please type a question first", response.content.decode())
+        mock_generate_text.assert_not_called()
+        mock_embed_text.assert_not_called()


### PR DESCRIPTION
Fixes the two remaining open issues (plus a confirmed review finding on the same path).

## #455 — chatbox textarea stays expanded
Enter inserted a newline on keydown, the autogrow input handler expanded the box, and the empty-text early return in `onSendButton` never cleared or reset it. Now Enter-without-shift is `preventDefault`ed on keydown (sending stays on keyup so the htmx trigger reads the value before it's cleared), and `onSendButton` always clears the field and resets the height. Dead `MutationObserver` removed.

## #429 — dark-on-dark text in dark mode
Text color was only applied via an explicit `:is(h1, h2, p, li, …)` element list; `body` had no `color`, so divs/spans/bare text (seeded posts, template text) stayed UA-black on the dark background. `body` now sets `color: var(--secondary-color)` so everything inherits the theme color; the `:is()` list is kept because it's load-bearing inside containers that set their own colors.

## Review finding (refs #455)
Empty Enter/send-button still fired a paid LLM call to `/answer-with-gpt/` and swapped in a bot-replies-to-nothing bubble. The htmx Enter trigger now filters on non-empty input, and the view short-circuits whitespace-only questions with a canned reply (mirrors `/generate-with-gpt/`'s existing empty guard). New test asserts the model is not called.

## Validation
- Full local gate: yamllint, ruff, collectstatic, migrate, pytest + coverage — **108 passed**, gitleaks clean
- Review fleet: 5 reviewers + adjudication; all findings resolved

Fixes #455
Fixes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)