### PR TITLE
ci: add GitHub Actions CI (Python gate)

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,27 @@
+name: Auto Merge
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    name: ci
+    runs-on: ubuntu-latest
+    # Mirror the pre-push gate's test-only Django settings (.git-hooks/pre-push).
+    env:
+      DEBUG: "False"
+      LOGGING: "False"
+      DJANGO_SETTINGS_MODULE: app.settings
+      USE_SQLITE: "True"
+      USE_CLOUD: "False"
+      SECURE_SSL_REDIRECT: "False"
+      SECRET_KEY: "Not applicable for tests"
+      ALLOWED_HOSTS: "127.0.0.1 localhost"
+      SITE_ID: "1"
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version-file: .python-version
+          cache: pip
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: yaml lint
+        run: yamllint .
+      - name: ruff lint
+        run: ruff check --config ./config/pyproject.toml app
+      - name: collectstatic
+        run: python manage.py collectstatic --noinput
+      - name: migrate
+        run: python manage.py migrate --noinput
+      - name: pytest + coverage
+        run: coverage run --rcfile=config/.coveragerc -m pytest tests
+      - name: coverage report
+        run: coverage report -m --skip-covered --rcfile=config/.coveragerc


### PR DESCRIPTION
## Summary

Adds GitHub Actions CI to this repo (it had none). The workflow mirrors the existing `.git-hooks/pre-push` quality gate so PRs and pushes to `main` are validated on GitHub.

- **`.github/workflows/ci.yml`** — single `ci` job on `ubuntu-latest`, Python from `.python-version` (3.14) with pip cache. Job-level `env:` block replicates the pre-push hook's test-only Django settings exactly. Steps run the same commands, in order: `yamllint .`, `ruff check --config ./config/pyproject.toml app`, `collectstatic --noinput`, `migrate --noinput`, `coverage run --rcfile=config/.coveragerc -m pytest tests`, then `coverage report`. `concurrency` cancels superseded runs; `permissions: contents: read`.
- **`.github/workflows/auto-merge.yml`** — fleet-standard auto-merge (byte-copy of shared-infra's).

**CI does not deploy.** Heroku deploys via its own GitHub integration on merge to `main`; this workflow only gates.

## Test plan

Ran the full gate locally in a provisioned worktree venv (Python 3.14) with the exact env vars: yamllint, ruff, collectstatic, migrate, and pytest+coverage all green — **108 passed**, coverage report renders (88% total).