### PR TITLE
docs: Local UI verification + DEFAULT_USER/PASSWORD

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,7 @@ AWS_SECRET_ACCESS_KEY=
 AWS_STORAGE_BUCKET_NAME=
 AWS_URL=  # URL of the S3 bucket
 DJANGO_STATIC_HOST=  # URL of the CloudFront distribution
+
+# Local browser-smoke / admin login (keep in sync with seeded accounts)
+DEFAULT_USER=admin
+DEFAULT_PASSWORD=admin

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ python manage.py recalculate_post_simularities
 python manage.py livereload
 ```
 
-Default seeded accounts: `admin/admin` and `comment_only/comment_only`.
+Default seeded accounts: `admin/admin` and `comment_only/comment_only`. For browser smoke / admin login, use `DEFAULT_USER` / `DEFAULT_PASSWORD` from `.env.local` (see `.env.example`; keep in sync with the seed).
 
 ## Architecture
 
@@ -97,3 +97,11 @@ Deploy is **automatic from GitHub `main`**: Heroku is connected to the GitHub re
 - Ruff config (`config/pyproject.toml`) ignores `E402`, `E501`, `F403` and excludes `apps.py` / `*/settings/*` — these accommodate Django star-imports, top-of-file `setup()` calls in tests, and intentional long lines.
 - Test convention: flat `tests/test_<module>.py` mirroring the source module, classes inheriting `SetUp` from `tests/base.py`.
 - Conventional Commits (`feat(blog): …`, `fix(users): …`).
+
+## Local UI verification
+
+Auth-gated admin/authoring UI (public blog pages need no login). Follow `rules/frontend-verification.md` (fleet smoke: desktop + mobile screenshots, console clean).
+
+- **Dev server:** with `.venv` activated — `python manage.py runserver` → <http://127.0.0.1:8000>
+- **Sign-in:** Django auth with `DEFAULT_USER` and `DEFAULT_PASSWORD` from `.env.local` (see `.env.example`). Keep these in sync with seeded accounts (local defaults: `admin` / `admin` after seed/setup).
+- **Do not** invent credentials or commit `.env.local`.


### PR DESCRIPTION
## Summary
- Add Local UI verification stanza to AGENTS.md for agent browser smoke after UI-affecting changes
- Document DEFAULT_USER/PASSWORD for smoke login from .env.local

## Test plan
- [ ] Confirm AGENTS.md Local UI verification section is present and clear
- [ ] Docs-only change — no runtime behavior to exercise

Made with [Cursor](https://cursor.com)