### PR TITLE
chore(cursor): Cloud Agent skills installer

### DIFF
--- a/.cursor/CLOUD.md
+++ b/.cursor/CLOUD.md
@@ -1,0 +1,23 @@
+# Cursor Cloud Agent notes
+
+This file is read by Cloud / Background Agents only (local IDE chat ignores it).
+Repo `AGENTS.md` still applies first; this file overlays cloud-specific facts.
+
+## Skills
+
+Public fleet skills are installed at `~/.cursor/skills` by `.cursor/install-cloud-skills.sh`
+(via `.cursor/environment.json` `install`). Source: <https://github.com/jsolly/agent-skills>
+(sanitized public mirror — not private `dotagents`).
+
+There is **no** `~/code/dotagents` on this VM. Do not look for it or claim child repos inherit it.
+
+If slash-skill autocomplete is empty on a follow-up turn, invoke the skill by name in prose
+(known Agents Window bug; typed invoke still works).
+
+Private laptop-only skills (e.g. `verify-ui`) are **not** available here. Follow this repo's
+`AGENTS.md` Local UI verification stanza for UI smoke instead of inventing `/verify-ui`.
+
+## Hooks / guards
+
+User-level `~/.cursor/hooks.json` from a laptop does **not** run in cloud. Only hooks committed
+under this repo's `.cursor/hooks.json` (or team/enterprise hooks) apply.

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,3 @@
+{
+  "install": "bash .cursor/install-cloud-skills.sh"
+}

--- a/.cursor/install-cloud-skills.sh
+++ b/.cursor/install-cloud-skills.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Install public jsolly/agent-skills into the Cursor Cloud Agent home skills path.
+# Cursor searches /home/ubuntu/.cursor/skills on cloud VMs (forum confirmation 2026-06).
+# Idempotent: safe to re-run from environment.json install/update.
+set -euo pipefail
+
+SKILLS_HOME="${CURSOR_CLOUD_SKILLS_HOME:-${HOME}/.cursor/skills}"
+MIRROR_URL="${AGENT_SKILLS_MIRROR_URL:-https://github.com/jsolly/agent-skills.git}"
+MIRROR_REF="${AGENT_SKILLS_MIRROR_REF:-main}"
+
+tmpdir="$(mktemp -d)"
+cleanup() { rm -rf "$tmpdir"; }
+trap cleanup EXIT
+
+echo "cloud-skills: cloning ${MIRROR_URL}@${MIRROR_REF} (shallow)"
+git clone --depth 1 --branch "$MIRROR_REF" "$MIRROR_URL" "$tmpdir/agent-skills"
+
+src="$tmpdir/agent-skills/skills"
+if [[ ! -d "$src" ]]; then
+  echo "cloud-skills: ERROR — no skills/ directory in mirror checkout" >&2
+  exit 1
+fi
+
+mkdir -p "$SKILLS_HOME"
+installed=0
+for skill_dir in "$src"/*/; do
+  [[ -d "$skill_dir" ]] || continue
+  name="$(basename "$skill_dir")"
+  if [[ ! -f "$skill_dir/SKILL.md" ]]; then
+    echo "cloud-skills: skip ${name} (no SKILL.md)"
+    continue
+  fi
+  dest="$SKILLS_HOME/$name"
+  rm -rf "$dest"
+  cp -R "$skill_dir" "$dest"
+  installed=$((installed + 1))
+  echo "cloud-skills: installed ${name} → ${dest}"
+done
+
+echo "cloud-skills: done (${installed} skill(s) under ${SKILLS_HOME})"

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ db.sqlite3-journal
 !.cursor/worktrees.json
 !.cursor/rules/
 !.cursor/rules/**
+!.cursor/CLOUD.md
+!.cursor/environment.json
+!.cursor/install-cloud-skills.sh
 
 
 # Materialized agent config (fetched by .dotagents/bootstrap.sh; not committed)


### PR DESCRIPTION
## Summary
- Wire Cursor Cloud Agents to install public skills from `jsolly/agent-skills` into `~/.cursor/skills`
- Add `.cursor/CLOUD.md` cloud-only overlay (no `~/code/dotagents` on the VM)
- Allowlist the three `.cursor/` files in `.gitignore` where needed

## Test plan
- [ ] Fresh Cloud Agent on this repo: skills `ship` / `janitor` / `research` loadable
- [ ] Agent does not claim `~/code/dotagents` exists


Made with [Cursor](https://cursor.com)