### PR TITLE
fix(seo): CF Insights CSP + CLS/a11y hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ processed/
 # Coverage files
 .coverage
 
+# Local SEO audit scratch (skill `/seo` baselines)
+.seo-audit/
+
 # Temp Files
 __pycache__/
 .DS_Store

--- a/app/settings.py
+++ b/app/settings.py
@@ -112,18 +112,24 @@ else:
         sys.exit(1)
 
 # Content Security Policy (django-csp 4.0 dict format)
+# Cloudflare Web Analytics (auto-injected beacon) — see
+# https://developers.cloudflare.com/web-analytics/faq/#what-do-i-need-to-add-to-my-content-security-policy-csp
+_CF_INSIGHTS_SCRIPT = "https://static.cloudflareinsights.com"
+_CF_INSIGHTS_CONNECT = "https://cloudflareinsights.com"
 _CSP_SCRIPT_SRC_ELEM = [
     "'self'",
     "'unsafe-inline'",
     STATIC_HOST,
+    _CF_INSIGHTS_SCRIPT,
 ]
 _CSP_SCRIPT_SRC = [
     "'self'",
     "'unsafe-eval'",
     "'unsafe-inline'",
     STATIC_HOST,
+    _CF_INSIGHTS_SCRIPT,
 ]
-_CSP_CONNECT_SRC = ["'self'"] + FULLY_QUALIFIED_ALLOWED_HOSTS
+_CSP_CONNECT_SRC = ["'self'", _CF_INSIGHTS_CONNECT] + FULLY_QUALIFIED_ALLOWED_HOSTS
 
 # Livereload.js is on 127.0.0.1:35729
 # There is never a reason to allow livereload.js in production

--- a/blog/templates/blog/base.html
+++ b/blog/templates/blog/base.html
@@ -92,7 +92,8 @@
       </main>
       <nav id="scroll-to-top-container" aria-label="Scroll to top">
         <a id="scroll-to-top" href="#">
-          <img id="scroll-to-top-icon" src="{% static 'svg/scroll-to-top.svg' %}" alt="Scroll to top of page">
+          <img id="scroll-to-top-icon" src="{% static 'svg/scroll-to-top.svg' %}" alt="Scroll to top of page"
+            width="45" height="45">
           top</a>
       </nav>
     </div>

--- a/blog/templates/blog/parts/about_me_card.html
+++ b/blog/templates/blog/parts/about_me_card.html
@@ -3,7 +3,7 @@
   <div class="post-card-row">
     <figure class="post-card-meta-img-container">
       <img id="about-me-image" src="{% static 'default.webp' %}" class="post-card-img about-me-image"
-        alt="John Solly Profile Picture" />
+        alt="John Solly Profile Picture" width="1207" height="1392" />
       <figcaption class="visually-hidden">
         John Solly Profile Picture
       </figcaption>

--- a/blog/templates/blog/parts/chatbox.html
+++ b/blog/templates/blog/parts/chatbox.html
@@ -4,7 +4,7 @@
         <div class="chatbox__support">
             <div class="chatbox__header">
                 <div class="chatbox__image--header">
-                    <img src="{% static 'svg/man-avatar.svg' %}" alt="Ezra's avatar">
+                    <img src="{% static 'svg/man-avatar.svg' %}" alt="Ezra's avatar" width="64" height="64">
                 </div>
                 <div class="chatbox__content--header">
                     <p class="chatbox__heading--header">Ezra</p>
@@ -29,6 +29,7 @@
                 <form id="chatbox-submit">
                     {% csrf_token %}
                     <div class="chatbox__input-container">
+                        <label class="visually-hidden" for="question-text-area">Send a message</label>
                         <textarea name="question-text-area" id="question-text-area" placeholder="Send a message..."
                             hx-trigger="keyup[key === 'Enter' && !shiftKey && target.value.trim() !== '']" hx-post="/answer-with-gpt/"
                             hx-include="#question-text-area" hx-target=".chatbox__messages"
@@ -53,7 +54,7 @@
         </div>
         <div class="chatbox__button">
             <button aria-label="Toggle chatbox">
-                <img id="chatbox-icon" src="{% static 'svg/chatbox-icon.svg' %}" alt="Chatbox icon" />
+                <img id="chatbox-icon" src="{% static 'svg/chatbox-icon.svg' %}" alt="" width="36" height="29" />
             </button>
         </div>
     </div>

--- a/blog/templates/blog/parts/header.html
+++ b/blog/templates/blog/parts/header.html
@@ -2,14 +2,16 @@
 <header>
   <nav class="navbar">
     <a class="navbar-brand" href="{% url 'home' %}">
-      <img id="blogthedata-logo" src="{% static 'logo_transparent_cropped.webp' %}" alt="BlogtheData" />
+      <img id="blogthedata-logo" src="{% static 'logo_transparent_cropped.webp' %}" alt="BlogtheData"
+        width="100" height="116" />
       Solly's Blog
     </a>
     <button type="button" class="hamburger">&#9776;</button>
     <div class="navbar-menu">
       <ul class="navbar-nav">
         <li class="nav-item dropdown nav-categories">
-          <a class="nav-link dropdown-toggle" href="#" role="button">
+          <a class="nav-link dropdown-toggle" href="#" role="button" id="header-navbarDropdown"
+            aria-haspopup="true" aria-expanded="false">
             Categories
           </a>
           <ul class="dropdown-menu" aria-labelledby="header-navbarDropdown">

--- a/blog/templates/blog/parts/post_card.html
+++ b/blog/templates/blog/parts/post_card.html
@@ -3,13 +3,14 @@
 {% load image_utils %}
 
 <article class="post">
-  <a href="{% url 'post-detail' post.slug %}" aria-label='{{ post.title }}'>
+  {# No aria-label: visible title/excerpt already name the link (avoids label-content-name-mismatch). #}
+  <a href="{% url 'post-detail' post.slug %}">
     <div class="post-card">
       <div class="post-card-row">
         <div class="post-card-meta-img-container">
           <figure>
             <img src="{% get_image_url post.metaimg %}" alt="{{ post.metaimg_alt_txt }}" class="post-card-img"
-              loading="lazy">
+              loading="lazy" {% image_dimension_attrs post.metaimg %}>
             <figcaption class="visually-hidden">{{ post.metaimg_alt_txt }}</figcaption>
           </figure>
         </div>
@@ -31,7 +32,7 @@
                   {% endif %}
                 </div>
                 <div class="post-readtime">
-                  <img src="{% static 'svg/clock.svg' %}" alt="Clock Icon" class="post-readtime-icon" />
+                  <img src="{% static 'svg/clock.svg' %}" alt="" class="post-readtime-icon" width="12" height="12" />
                   <span class="post-readtime-text">{{ post.content|readtime }}</span>
                 </div>
               </div>
@@ -40,7 +41,7 @@
               </div>
             </div>
             <div class="comment-details">
-              <img src="{% static 'svg/comment-icon.svg' %}" alt="Comment Icon" class="comment-icon">
+              <img src="{% static 'svg/comment-icon.svg' %}" alt="" class="comment-icon" width="20" height="24">
               <p>{{ post.comments.count }}</p>
             </div>
           </div>

--- a/blog/templates/blog/post/post_detail.html
+++ b/blog/templates/blog/post/post_detail.html
@@ -76,7 +76,8 @@
         {% endif %}
       </h1>
       <div class="meta-img-container">
-        <img id="post-detail-meta-img" src="{% get_image_url post.metaimg %}" alt="{{ post.metadesc }}">
+        <img id="post-detail-meta-img" src="{% get_image_url post.metaimg %}" alt="{{ post.metadesc }}"
+          {% if metaimg_width %}width="{{ metaimg_width }}" height="{{ metaimg_height }}"{% endif %}>
       </div>
       <p class="post-dates sml-margin-top-bottom">
         <time datetime="{{ post.date_posted|date:"Y-m-d" }}">{{ post.date_posted|date:"F d, Y" }}</time> in {{ post.category.name }}
@@ -98,7 +99,7 @@
     {% endif %}
     <div class="sml-margin-top-bottom" id="print-container">
       <a class="btn btn-dark" href="javascript:window.print()">
-        <img id="print-icon" src="{% static 'svg/print-icon.svg' %}" alt="Print this blog post">
+        <img id="print-icon" src="{% static 'svg/print-icon.svg' %}" alt="Print this blog post" width="24" height="24">
         <span id="print-text">Print this post</span>
       </a>
     </div>

--- a/blog/templatetags/image_utils.py
+++ b/blog/templatetags/image_utils.py
@@ -61,3 +61,26 @@ def get_image_url(image_field):
         return f"{settings.STATIC_HOST}/{settings.MEDIA_LOCATION}/{image_field.name}"
     else:
         return f"/mediafiles/{image_field.name}"
+
+
+# Intrinsic size of static/default.webp (Post.metaimg default) — avoid opening storage.
+_DEFAULT_METAIMG_WH = (1207, 1392)
+
+
+@register.simple_tag
+def image_dimension_attrs(image_field, default_width=1200, default_height=630):
+    """Return safe width=/height= attributes for CLS without 500ing on missing media."""
+    if not image_field:
+        return ""
+    name = getattr(image_field, "name", "") or ""
+    if name.endswith("default.webp"):
+        w, h = _DEFAULT_METAIMG_WH
+        return mark_safe(f'width="{w}" height="{h}"')
+    try:
+        w, h = image_field.width, image_field.height
+    except (ValueError, OSError) as exc:
+        logger.warning("image dimensions unavailable; using defaults (%s)", exc)
+        return mark_safe(f'width="{default_width}" height="{default_height}"')
+    if w and h:
+        return mark_safe(f'width="{w}" height="{h}"')
+    return mark_safe(f'width="{default_width}" height="{default_height}"')

--- a/static/js/header.js
+++ b/static/js/header.js
@@ -13,6 +13,10 @@ document.addEventListener("DOMContentLoaded", () => {
       event.preventDefault();
       const dropdownMenu = toggle.nextElementSibling;
       dropdownMenu.classList.toggle("show");
+      toggle.setAttribute(
+        "aria-expanded",
+        String(dropdownMenu.classList.contains("show")),
+      );
     });
   });
 });

--- a/tests/test_seo_meta.py
+++ b/tests/test_seo_meta.py
@@ -25,6 +25,43 @@ class SeoMetaTests(SetUp):
     """Locks in the SEO head fixes: clean canonical, un-prefixed social image,
     a single canonical on /all-posts/, and valid JSON-LD on post pages."""
 
+    def test_csp_allows_cloudflare_web_analytics_beacon(self):
+        # Auto-injected CF Insights beacon is blocked without these hosts
+        # (Lighthouse Best-Practices / console CSP errors on prod).
+        csp = self.client.get("/").headers.get("Content-Security-Policy", "")
+        directives = {
+            part.split(None, 1)[0]: part.split(None, 1)[1]
+            for part in csp.split(";")
+            if part.strip() and " " in part.strip()
+        }
+        script_src = " ".join(
+            directives.get(k, "") for k in ("script-src", "script-src-elem")
+        )
+        self.assertIn("https://static.cloudflareinsights.com", script_src)
+        self.assertIn(
+            "https://cloudflareinsights.com", directives.get("connect-src", "")
+        )
+
+    def test_homepage_post_cards_use_visible_text_not_aria_label(self):
+        html = self.client.get("/").content.decode()
+        # Post cards wrap the whole card in <a>; naming comes from visible title text.
+        cards = re.findall(r'<article class="post">.*?</article>', html, re.DOTALL)
+        self.assertGreater(len(cards), 0)
+        for card in cards:
+            self.assertNotIn("aria-label=", card)
+
+    def test_header_categories_dropdown_has_labelledby_target(self):
+        html = self.client.get("/").content.decode()
+        self.assertIn('id="header-navbarDropdown"', html)
+        self.assertIn('aria-labelledby="header-navbarDropdown"', html)
+
+    def test_chatbox_textarea_has_associated_label(self):
+        html = self.client.get("/").content.decode()
+        self.assertRegex(
+            html,
+            r'<label\b[^>]*\bfor="question-text-area"[^>]*>\s*Send a message\s*</label>',
+        )
+
     def test_homepage_canonical_points_at_root_with_trailing_slash(self):
         html = self.client.get("/").content.decode()
         self.assertEqual(_canonical_hrefs(html), ["http://testserver/"])


### PR DESCRIPTION
## Summary
- Allow Cloudflare Web Analytics hosts in Django CSP so the auto-injected beacon stops failing Lighthouse Best-Practices / console CSP checks.
- Add safe image dimension attributes for CLS (guarded tag + post-detail context), fix Categories `aria-labelledby`/expanded wiring, and give the chatbox textarea a real label.
- Ignore `.seo-audit/` scratch; GSC sitemap was resubmitted during the `/seo` audit.

## Test plan
- [x] `pytest tests/test_seo_meta.py` (CSP directive placement, post-card a11y, header/chatbox labels)
- [x] Pre-commit gate (ruff, collectstatic, migrate, pytest + coverage)
- [ ] After deploy: Lighthouse Best-Practices re-median on homepage (expect CF beacon no longer CSP-blocked)
- [ ] Spot-check Categories dropdown `aria-expanded` toggles with menu


Made with [Cursor](https://cursor.com)