### PR TITLE
fix(seo): restore post-card link names after htmlmin

### DIFF
--- a/blog/templates/blog/parts/post_card.html
+++ b/blog/templates/blog/parts/post_card.html
@@ -2,51 +2,51 @@
 {% load static %}
 {% load image_utils %}
 
+{# Title link + stretched ::after — avoid wrapping the card in <a>. django-htmlmin #}
+{# splits block-in-anchor into empty nameless <a>s, which tanks Lighthouse link-name. #}
 <article class="post">
-  {# No aria-label: visible title/excerpt already name the link (avoids label-content-name-mismatch). #}
-  <a href="{% url 'post-detail' post.slug %}">
-    <div class="post-card">
-      <div class="post-card-row">
-        <div class="post-card-meta-img-container">
-          <figure>
-            <img src="{% get_image_url post.metaimg %}" alt="{{ post.metaimg_alt_txt }}" class="post-card-img"
-              loading="lazy" {% image_dimension_attrs post.metaimg %}>
-            <figcaption class="visually-hidden">{{ post.metaimg_alt_txt }}</figcaption>
-          </figure>
-        </div>
-        <div class="post-card-content">
-          <div class="post-card-info">
-            <div class="post-body">
-              <div class="post-header">
-                <h2 class="post-title">{{ post.title }}
-                  {% if post.draft %}
-                  <span class="post-draft">(Draft)</span>
-                  {% endif %}
-                </h2>
+  <div class="post-card">
+    <div class="post-card-row">
+      <div class="post-card-meta-img-container">
+        <figure>
+          <img src="{% get_image_url post.metaimg %}" alt="{{ post.metaimg_alt_txt }}" class="post-card-img"
+            loading="lazy" {% image_dimension_attrs post.metaimg %}>
+          <figcaption class="visually-hidden">{{ post.metaimg_alt_txt }}</figcaption>
+        </figure>
+      </div>
+      <div class="post-card-content">
+        <div class="post-card-info">
+          <div class="post-body">
+            <div class="post-header">
+              <h2 class="post-title">
+                <a class="post-card-link" href="{% url 'post-detail' post.slug %}">{{ post.title }}</a>
+                {% if post.draft %}
+                <span class="post-draft">(Draft)</span>
+                {% endif %}
+              </h2>
+            </div>
+            <div class="post-info">
+              <time datetime="{{ post.date_posted|date:" Y-m-d" }}">{{ post.date_posted|date:"F d, Y" }}</time> in {{ post.category.name }}
+              <div class="post-updated">
+                {% if post.date_updated|date:"Ymd" != post.date_posted|date:"Ymd" %}
+                Last updated: <time datetime="{{ post.date_updated|date:" Y-m-d" }}">{{ post.date_updated|date:"F d, Y" }}</time>
+                {% endif %}
               </div>
-              <div class="post-info">
-                <time datetime="{{ post.date_posted|date:" Y-m-d" }}">{{ post.date_posted|date:"F d, Y" }}</time> in {{ post.category.name }}
-                <div class="post-updated">
-                  {% if post.date_updated|date:"Ymd" != post.date_posted|date:"Ymd" %}
-                  Last updated: <time datetime="{{ post.date_updated|date:" Y-m-d" }}">{{ post.date_updated|date:"F d, Y" }}</time>
-                  {% endif %}
-                </div>
-                <div class="post-readtime">
-                  <img src="{% static 'svg/clock.svg' %}" alt="" class="post-readtime-icon" width="12" height="12" />
-                  <span class="post-readtime-text">{{ post.content|readtime }}</span>
-                </div>
-              </div>
-              <div class="post-excerpt">
-                {{ post.snippet|safe }}
+              <div class="post-readtime">
+                <img src="{% static 'svg/clock.svg' %}" alt="" class="post-readtime-icon" width="12" height="12" />
+                <span class="post-readtime-text">{{ post.content|readtime }}</span>
               </div>
             </div>
-            <div class="comment-details">
-              <img src="{% static 'svg/comment-icon.svg' %}" alt="" class="comment-icon" width="20" height="24">
-              <p>{{ post.comments.count }}</p>
+            <div class="post-excerpt">
+              {{ post.snippet|safe }}
             </div>
+          </div>
+          <div class="comment-details">
+            <img src="{% static 'svg/comment-icon.svg' %}" alt="" class="comment-icon" width="20" height="24">
+            <p>{{ post.comments.count }}</p>
           </div>
         </div>
       </div>
     </div>
-  </a>
+  </div>
 </article>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -397,6 +397,20 @@ footer .dropdown-menu {
   margin-bottom: 30px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   border-radius: 0.25rem;
+  position: relative;
+}
+
+/* Full-card hit target from the title link (keeps AccName = title text). */
+a.post-card-link::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+
+.post-excerpt a {
+  position: relative;
+  z-index: 2;
 }
 
 .post-card-row {

--- a/tests/test_seo_meta.py
+++ b/tests/test_seo_meta.py
@@ -41,10 +41,18 @@ class SeoMetaTests(SetUp):
         cards = re.findall(r'<article class="post">.*?</article>', html, re.DOTALL)
         self.assertGreater(len(cards), 0)
         for card in cards:
-            self.assertIn('class="post-card-link"', card)
             self.assertNotIn("aria-label=", card)
-            # No empty href-only anchors left behind by htmlmin.
-            self.assertIsNone(re.search(r'<a href="[^"]+"></a>', card))
+            # AccName must come from visible title text inside the stretched link
+            # (empty <a class="post-card-link"> would still fail Lighthouse link-name).
+            title_link = re.search(
+                r'<a\b[^>]*\bclass="post-card-link"[^>]*>(.*?)</a>',
+                card,
+                re.DOTALL,
+            )
+            self.assertIsNotNone(title_link)
+            self.assertTrue(title_link.group(1).strip())
+            # No empty anchors left behind by htmlmin (attrs/whitespace variants).
+            self.assertIsNone(re.search(r'<a\b[^>]*href="[^"]+"[^>]*>\s*</a>', card))
 
     def test_header_categories_dropdown_has_labelledby_target(self):
         html = self.client.get("/").content.decode()

--- a/tests/test_seo_meta.py
+++ b/tests/test_seo_meta.py
@@ -29,26 +29,22 @@ class SeoMetaTests(SetUp):
         # Auto-injected CF Insights beacon is blocked without these hosts
         # (Lighthouse Best-Practices / console CSP errors on prod).
         csp = self.client.get("/").headers.get("Content-Security-Policy", "")
-        directives = {
-            part.split(None, 1)[0]: part.split(None, 1)[1]
-            for part in csp.split(";")
-            if part.strip() and " " in part.strip()
-        }
-        script_src = " ".join(
-            directives.get(k, "") for k in ("script-src", "script-src-elem")
+        self.assertRegex(
+            csp, r"script-src(?:-elem)?[^;]*https://static\.cloudflareinsights\.com"
         )
-        self.assertIn("https://static.cloudflareinsights.com", script_src)
-        self.assertIn(
-            "https://cloudflareinsights.com", directives.get("connect-src", "")
-        )
+        self.assertRegex(csp, r"connect-src[^;]*https://cloudflareinsights\.com")
 
-    def test_homepage_post_cards_use_visible_text_not_aria_label(self):
+    def test_homepage_post_cards_use_named_title_link_not_wrapping_anchor(self):
         html = self.client.get("/").content.decode()
-        # Post cards wrap the whole card in <a>; naming comes from visible title text.
+        # Stretched title link (not a wrapping <a>) — htmlmin used to split block-in-anchor
+        # into empty nameless links and tank Lighthouse link-name.
         cards = re.findall(r'<article class="post">.*?</article>', html, re.DOTALL)
         self.assertGreater(len(cards), 0)
         for card in cards:
+            self.assertIn('class="post-card-link"', card)
             self.assertNotIn("aria-label=", card)
+            # No empty href-only anchors left behind by htmlmin.
+            self.assertIsNone(re.search(r'<a href="[^"]+"></a>', card))
 
     def test_header_categories_dropdown_has_labelledby_target(self):
         html = self.client.get("/").content.decode()


### PR DESCRIPTION
## Summary
- Replace wrapping post-card `<a>` with a title stretched-link so django-htmlmin no longer emits empty nameless anchors (Lighthouse `link-name` regression after #588).
- Keep full-card click target via `a.post-card-link::after`; excerpt links stay above the overlay with `z-index: 2`.
- Strengthen SEO tests to require non-empty title-link text and reject empty-anchor remnants.

## Test plan
- [x] Local pre-commit gate (ruff, collectstatic, migrate, pytest + coverage)
- [x] `tests/test_seo_meta.py` post-card AccName lock
- [ ] CI green on PR
- [ ] After merge: Heroku release for merge SHA; prod homepage has named `post-card-link` (no empty `<a href>` cards); Lighthouse Accessibility ~100 / no `link-name` fail


Made with [Cursor](https://cursor.com)